### PR TITLE
Use std::borrow for Matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Bump `envisim_utils`
+
 ## [0.4.0] - 2025-08-22
 ### Changed
 - Update `rustc-hash` dependency to 2.1.1.

--- a/envisim_estimate/CHANGELOG.md
+++ b/envisim_estimate/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Bump `envisim_utils`
+
 ## [0.3.1] - 2025-08-22
 ### Changed
 - Update `rustc-hash` dependency to 2.1.1.

--- a/envisim_estimate/src/balance.rs
+++ b/envisim_estimate/src/balance.rs
@@ -31,7 +31,7 @@ pub type BalanceDeviationResult = (Option<Vec<f64>>, Option<Vec<f64>>);
 /// use envisim_utils::kd_tree::TreeBuilder;
 ///
 /// let p = [0.2, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9];
-/// let m = Matrix::from_vec(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 10);
+/// let m = Matrix::from_vec(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 10).unwrap();
 /// let options = SampleOptions::new(&p)?.set_spreading(&m)?;
 /// let s = [0, 3, 5, 8, 9];
 ///

--- a/envisim_estimate/src/spatial_balance.rs
+++ b/envisim_estimate/src/spatial_balance.rs
@@ -28,7 +28,7 @@ use rustc_hash::{FxBuildHasher, FxHashMap};
 /// use envisim_utils::kd_tree::TreeBuilder;
 ///
 /// let p = [0.2, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9];
-/// let m = Matrix::from_vec(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 10);
+/// let m = Matrix::from_vec(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 10).unwrap();
 /// let options = SampleOptions::new(&p)?.set_spreading(&m)?;
 /// let s = [0, 3, 5, 8, 9];
 ///
@@ -91,7 +91,7 @@ pub fn voronoi(sample: &[usize], options: &SampleOptions) -> Result<f64, Samplin
 /// use envisim_utils::kd_tree::TreeBuilder;
 ///
 /// let p = [0.2, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9];
-/// let m = Matrix::from_vec(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 10);
+/// let m = Matrix::from_vec(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 10).unwrap();
 /// let options = SampleOptions::new(&p)?.set_spreading(&m)?;
 /// let s = [0, 3, 5, 8, 9];
 ///
@@ -128,7 +128,7 @@ pub fn local(sample: &[usize], options: &SampleOptions) -> Result<f64, SamplingE
         FxHashMap::<usize, Vec<f64>>::with_capacity_and_hasher(sample_size, FxBuildHasher);
 
     // The gram matrix
-    let mut norm_matrix = Matrix::from_value(0.0, (cols, cols * 2));
+    let mut norm_matrix = Matrix::from_value(0.0, (cols, cols * 2)).unwrap();
 
     for i in 0..cols {
         norm_matrix[(i, i + cols)] = 1.0;
@@ -184,12 +184,16 @@ pub fn local(sample: &[usize], options: &SampleOptions) -> Result<f64, SamplingE
     let inv_matrix = Matrix::new(
         &norm_matrix.data()[norm_matrix.nrow().pow(2)..],
         norm_matrix.nrow(),
-    );
+    )
+    .unwrap();
 
     let result = voronoi_means.iter().fold(0.0, |acc, (_, vec)| {
-        acc + Matrix::from_ref(vec, 1)
+        acc + Matrix::new(vec, 1)
+            .unwrap()
             .mult(&inv_matrix)
-            .mult(&Matrix::from_ref(vec, cols))
+            .unwrap()
+            .mult(&Matrix::new(vec, cols).unwrap())
+            .unwrap()
             .data()[0]
     });
 

--- a/envisim_estimate/tests/balance.rs
+++ b/envisim_estimate/tests/balance.rs
@@ -5,7 +5,7 @@ use envisim_utils::Matrix;
 
 #[test]
 fn test_balance() -> Result<(), SamplingError> {
-    let data = Matrix::new(&DATA_10_2, 10);
+    let data = Matrix::new(&DATA_10_2, 10).unwrap();
     let mut options = SampleOptions::new(&PROB_10_E)?.set_spreading(&data)?;
 
     let sb = balance_deviation(&[0], &options)?;

--- a/envisim_estimate/tests/spatial_balance.rs
+++ b/envisim_estimate/tests/spatial_balance.rs
@@ -5,7 +5,7 @@ use envisim_utils::Matrix;
 
 #[test]
 fn test_voronoi() -> Result<(), SamplingError> {
-    let data = Matrix::new(&DATA_10_2, 10);
+    let data = Matrix::new(&DATA_10_2, 10).unwrap();
     let options = SampleOptions::new(&PROB_10_E)?.set_spreading(&data)?;
 
     let sb = voronoi(&[0], &options)?;
@@ -16,7 +16,7 @@ fn test_voronoi() -> Result<(), SamplingError> {
 
 #[test]
 fn test_local() -> Result<(), SamplingError> {
-    let data = Matrix::new(&DATA_10_2, 10);
+    let data = Matrix::new(&DATA_10_2, 10).unwrap();
     let options = SampleOptions::new(&PROB_10_E)?.set_spreading(&data)?;
 
     let sb = local(&[0], &options)?;

--- a/envisim_utils/CHANGELOG.md
+++ b/envisim_utils/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Matrix use std::borrow instead of reinventing the wheel.
+- MatrixIndex as struct instead of tuple.
+- Most Matrix methods are allowed to fail by returning Option.
+- Matrix::dim renamed to Matrix::dims
+
 ## [0.3.0] - 2025-08-22
 ### Changed
 - Changed `rand` into an optional dependency, activated by feature `rand` (default).

--- a/envisim_utils/src/kd_tree/node.rs
+++ b/envisim_utils/src/kd_tree/node.rs
@@ -326,14 +326,12 @@ impl std::fmt::Display for NodeError {
 mod tests {
     use super::*;
 
+    static MATRIX_DATA: [f64; 10] = [
+        0.0, 1.0, 2.0, 13.0, 14.0, //
+        0.0, 10.0, 20.0, 30.0, 40.0, //
+    ];
     fn matrix_new<'a>() -> Matrix<'a> {
-        Matrix::new(
-            &[
-                0.0, 1.0, 2.0, 13.0, 14.0, //
-                0.0, 10.0, 20.0, 30.0, 40.0, //
-            ],
-            5,
-        )
+        Matrix::new(&MATRIX_DATA, 5).unwrap()
     }
 
     #[test]

--- a/envisim_utils/src/kd_tree/searcher.rs
+++ b/envisim_utils/src/kd_tree/searcher.rs
@@ -153,7 +153,7 @@ impl Searcher {
                 return;
             }
 
-            let distance = data.distance_to_row(id, &self.unit);
+            let distance = data.distance_to_row(id, &self.unit).unwrap();
 
             if distance < current_max {
                 self.reset();
@@ -175,7 +175,7 @@ impl Searcher {
                 return;
             }
 
-            let distance = data.distance_to_row(id, &self.unit);
+            let distance = data.distance_to_row(id, &self.unit).unwrap();
 
             // We should add a unit only in two circumstances:
             // - if the unit is closer than the current largest dist
@@ -369,7 +369,7 @@ impl<'a> TreeSearcherWeighted<'a> {
                 return;
             }
 
-            let distance = data.distance_to_row(id, &self.base().unit);
+            let distance = data.distance_to_row(id, &self.base().unit).unwrap();
 
             // We should add a unit only in two circumstances:
             // - if the unit is closer than the current largest dist

--- a/envisim_utils/src/kd_tree/split_methods.rs
+++ b/envisim_utils/src/kd_tree/split_methods.rs
@@ -133,14 +133,14 @@ mod tests {
     #[test]
     fn midpoint_slide() {
         let v = vec![0.0, 1.0, 2.0, 13.0];
-        let m = Matrix::new(&v, 4);
+        let m = Matrix::new(&v, 4).unwrap();
         let split = super::midpoint_slide(&vec![(0.0, 13.0)], &m, &mut vec![0, 1, 2, 3]).unwrap();
         assert_eq!(split.unit, 3);
         assert_eq!(split.dimension, 0);
         assert_eq!(split.value, 6.5);
 
         let v = vec![0.0, 1.0, 2.0, 13.0, 0.0, 10.0, 20.0, 30.0];
-        let m = Matrix::new(&v, 4);
+        let m = Matrix::new(&v, 4).unwrap();
         let split =
             super::midpoint_slide(&vec![(0.0, 13.0), (0.0, 30.0)], &m, &mut vec![0, 1, 2, 3])
                 .unwrap();
@@ -149,7 +149,7 @@ mod tests {
         assert_eq!(split.value, 15.0);
 
         let v = vec![0.0, 0.0, 0.0, 1.0, 1.0, 1.0];
-        let m = Matrix::new(&v, 3);
+        let m = Matrix::new(&v, 3).unwrap();
         let split = super::midpoint_slide(&vec![(0.0, 0.0), (1.0, 1.0)], &m, &mut vec![0, 1, 2]);
         assert!(split.is_none());
     }

--- a/envisim_utils/src/lib.rs
+++ b/envisim_utils/src/lib.rs
@@ -23,5 +23,5 @@ pub mod utils;
 
 pub use error::InputError;
 pub use indices::{Indices, IndicesError};
-pub use matrix::Matrix;
+pub use matrix::{Matrix, MatrixIndex, MatrixIterator};
 pub use probabilities::Probabilities;

--- a/envisim_utils/src/matrix.rs
+++ b/envisim_utils/src/matrix.rs
@@ -14,127 +14,139 @@
 //! - [`Matrix`], which is a mutable matrix owning it's own storage.
 //! - [`RefMatrix`], which provides matrix operations on a provided, immutable vector.
 
+use std::borrow::Cow;
 use std::iter::{Skip, StepBy};
 use std::ops::{Index, IndexMut};
 use std::slice::Iter;
 
 /// Matrix dimensions `(row, col)`
-type MatrixIndex = (usize, usize);
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct MatrixIndex(pub usize, pub usize);
 
-#[allow(clippy::exhaustive_enums)]
-pub enum MatrixData<'a> {
-    Mutable(Vec<f64>),
-    Reference(&'a [f64]),
+impl MatrixIndex {
+    #[inline]
+    pub fn try_from_slice(v: &[f64], rows: usize) -> Option<Self> {
+        if rows == 0 || v.len() % rows > 0 {
+            return None;
+        }
+        let cols = v.len() / rows;
+
+        Some(MatrixIndex(rows, cols))
+    }
+    #[inline]
+    pub fn row(&self) -> usize {
+        self.0
+    }
+    #[inline]
+    pub fn col(&self) -> usize {
+        self.1
+    }
+    #[inline]
+    pub fn size(&self) -> usize {
+        self.row() * self.col()
+    }
+    #[inline]
+    pub fn transpose(&self) -> Self {
+        MatrixIndex(self.1, self.0)
+    }
+    #[inline]
+    pub fn to_index(&self, size: impl Into<MatrixIndex>) -> Option<usize> {
+        let size = size.into();
+        (self.row() < size.row() && self.col() < size.col())
+            .then_some(self.row() + self.col() * size.row())
+    }
+    #[inline]
+    pub fn new(idx: impl Into<MatrixIndex>) -> Self {
+        idx.into()
+    }
+    #[inline]
+    pub fn into_index(idx: impl Into<MatrixIndex>, size: impl Into<MatrixIndex>) -> Option<usize> {
+        let idx = idx.into();
+        let size = size.into();
+        (idx.row() < size.row() && idx.col() < size.col())
+            .then_some(idx.row() + idx.col() * size.row())
+    }
 }
 
+impl From<(usize, usize)> for MatrixIndex {
+    fn from(idx: (usize, usize)) -> Self {
+        MatrixIndex(idx.0, idx.1)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub struct Matrix<'a> {
-    data: MatrixData<'a>,
-    rows: usize,
-    cols: usize,
+    data: Cow<'a, [f64]>,
+    dims: MatrixIndex,
 }
 
 impl<'a> Matrix<'a> {
+    /// Clones the underlying data if it was borrowed
     #[inline]
-    fn matrix_index(&self, (row, col): MatrixIndex) -> usize {
-        assert!(col < self.cols, "col {} larger than max {}", col, self.cols);
-        assert!(row < self.rows, "row {} larger than max {}", row, self.rows);
-        row + col * self.rows
-    }
-    // #[inline]
-    // unsafe fn matrix_index_unchecked(&self, (row, col): MatrixIndex) -> usize {
-    //     col * self.rows + row
-    // }
-    /// If the matrix is a reference matrix, this method clones the underlying data and transforms
-    /// self into a mutable matrix.
-    /// Calling the method on a mutable matrix is a noop.
-    #[inline]
-    pub fn to_mut(&mut self) -> &Self {
-        if let MatrixData::Reference(v) = self.data {
-            self.data = MatrixData::Mutable(v.to_vec());
-        }
+    pub fn to_mut(&mut self) -> &mut Self {
+        self.data.to_mut();
         self
     }
-    /// Constructs a new mutable matrix, by copying the `data`.
+    /// Constructs a new matrix, by borrowing the data.
     #[inline]
-    pub fn new(data: &[f64], rows: usize) -> Self {
-        assert!(rows > 0);
-        assert!(data.len() % rows == 0);
-        let cols = data.len() / rows;
-        Self {
-            data: MatrixData::Mutable(data.to_vec()),
-            rows,
-            cols,
-        }
+    pub fn new(data: &'a [f64], rows: usize) -> Option<Self> {
+        let dims = MatrixIndex::try_from_slice(data, rows)?;
+        let m = Self {
+            data: Cow::Borrowed(data),
+            dims,
+        };
+        Some(m)
     }
-    /// Constructs a new mutable matrix, by moving the `data`.
+    /// Constructs a new matrix, by moving the `data`.
     #[inline]
-    pub fn from_vec(data: Vec<f64>, rows: usize) -> Self {
-        assert!(rows > 0);
-        assert!(data.len() % rows == 0);
-        let cols = data.len() / rows;
-        Self {
-            data: MatrixData::Mutable(data),
-            rows,
-            cols,
-        }
+    pub fn from_vec(data: Vec<f64>, rows: usize) -> Option<Self> {
+        let dims = MatrixIndex::try_from_slice(&data, rows)?;
+        let m = Self {
+            data: Cow::Owned(data),
+            dims,
+        };
+        Some(m)
     }
-    /// Constructs a new mutable matrix, filled with `data`
+    /// Constructs a new matrix of size `dims` filled with `data`
     #[inline]
-    pub fn from_value(data: f64, (rows, cols): MatrixIndex) -> Self {
-        assert!(rows > 0);
-        assert!(cols > 0);
-        Self {
-            data: MatrixData::Mutable(vec![data; rows * cols]),
-            rows,
-            cols,
+    pub fn from_value(data: f64, dims: impl Into<MatrixIndex>) -> Option<Self> {
+        let dims = dims.into();
+        let size = dims.size();
+        if size == 0 {
+            return None;
         }
-    }
-    /// Constructs a new reference matrix by `data`
-    #[inline]
-    pub fn from_ref(data: &'a [f64], rows: usize) -> Self {
-        assert!(rows > 0);
-        assert!(data.len() % rows == 0);
-        let cols = data.len() / rows;
-        Self {
-            data: MatrixData::Reference(data),
-            rows,
-            cols,
-        }
+
+        let m = Self {
+            data: Cow::Owned(vec![data; size]),
+            dims,
+        };
+        Some(m)
     }
     /// Returns the underlying data (stored in column major).
     #[inline]
     pub fn data(&self) -> &[f64] {
-        match self.data {
-            MatrixData::Mutable(ref v) => v.as_slice(),
-            MatrixData::Reference(v) => v,
-        }
+        self.data.as_ref()
     }
     /// Returns the underlying data (stored in column major).
-    /// If the matrix is a reference matrix, the matrix is transformed to a mutable matrix.
+    /// If the data is a borrowed, it is first cloned.
     #[inline]
     pub fn data_mut(&mut self) -> &mut [f64] {
-        match self.data {
-            MatrixData::Mutable(ref mut v) => v.as_mut_slice(),
-            _ => {
-                self.to_mut();
-                self.data_mut()
-            }
-        }
+        self.data.to_mut()
     }
     /// Returns the number of rows in the matrix
     #[inline]
     pub fn nrow(&self) -> usize {
-        self.rows
+        self.dims.row()
     }
     /// Returns the number of columns in the matrix
     #[inline]
     pub fn ncol(&self) -> usize {
-        self.cols
+        self.dims.col()
     }
     /// Returns the dimensions of the matrix
     #[inline]
-    pub fn dim(&self) -> (usize, usize) {
-        (self.rows, self.cols)
+    pub fn dims(&self) -> MatrixIndex {
+        self.dims
     }
     /// Returns an iterator on the row
     #[inline]
@@ -142,7 +154,7 @@ impl<'a> Matrix<'a> {
         assert!(row < self.nrow());
         MatrixIterator {
             iter: self.data().iter().skip(row).step_by(self.nrow()),
-            dim: self.dim(),
+            dims: self.dims(),
             step: self.nrow(),
             count: 0,
         }
@@ -157,62 +169,51 @@ impl<'a> Matrix<'a> {
                 .iter()
                 .skip(0)
                 .step_by(1),
-            dim: self.dim(),
+            dims: self.dims(),
             step: 1,
             count: 0,
         }
     }
     /// Resizes the matrix, without guaranteeing the preservation of any data.
-    /// If the matrix is a reference matrix, the matrix is transformed to a mutable matrix.
+    /// If matrix is extend, data is cloned
     #[inline]
-    pub fn resize(&mut self, (rows, cols): MatrixIndex) -> &Self {
-        assert!(rows > 0 && cols > 0);
-        let new_size = rows * cols;
-
-        match self.data {
-            MatrixData::Mutable(ref mut v) => {
-                v.resize(new_size, 0.0);
-            }
-            _ => {
-                self.to_mut();
-                return self.resize((rows, cols));
-            }
+    pub fn resize(&mut self, dims: impl Into<MatrixIndex>) -> Option<&mut Self> {
+        let dims = dims.into();
+        if dims.row() == 0 || dims.col() == 0 {
+            return None;
         }
 
-        self.rows = rows;
-        self.cols = cols;
-        self
+        // let old_size = self.dims().size();
+        let new_size = dims.size();
+
+        self.data.to_mut().resize(new_size, 0.0);
+        self.dims = dims;
+        Some(self)
     }
     /// Calculates the reduced row echelon form of the matrix, in place.
-    /// If the matrix is a reference matrix, the matrix is transformed to a mutable matrix.
     pub fn reduced_row_echelon_form(&mut self) {
-        let index = |midx: MatrixIndex| midx.0 + midx.1 * self.rows;
-        let data = match self.data {
-            MatrixData::Mutable(ref mut v) => v.as_mut_slice(),
-            _ => {
-                self.to_mut();
-                return self.reduced_row_echelon_form();
-            }
-        };
+        let dims = self.dims();
+        let index = |row, col| row + col * dims.row();
+        let data = self.data.to_mut();
 
         let mut lead: usize = 0;
 
-        for row in 0..self.rows {
-            if self.cols <= lead {
+        for row in 0..dims.row() {
+            if dims.col() <= lead {
                 return;
             }
 
             let mut i: usize = row;
 
-            while unsafe { *data.get_unchecked(index((i, lead))) == 0.0 } {
+            while data[index(i, lead)] == 0.0 {
                 i += 1;
 
-                if i == self.rows {
+                if i == dims.row() {
                     i = row;
                     lead += 1;
                 }
 
-                if lead == self.cols {
+                if lead == dims.col() {
                     return;
                 }
             }
@@ -221,54 +222,47 @@ impl<'a> Matrix<'a> {
             if i != row {
                 let mut index_i = i;
                 let mut index_row = row;
-                for _ in 0..self.cols {
+                for _ in 0..dims.col() {
                     data.swap(index_i, index_row);
-                    index_i += self.rows;
-                    index_row += self.rows;
+                    index_i += dims.row();
+                    index_row += dims.row();
                 }
             }
 
             // Divide ROW by lead, assuming all is 0 before lead
-            let mut index_row = index((row, lead));
+            let mut index_row = index(row, lead);
             let lead_value = unsafe { *data.get_unchecked(index_row) };
             if lead_value != 1.0 {
-                unsafe {
-                    *data.get_unchecked_mut(index_row) = 1.0;
-                }
-                index_row += self.rows;
+                data[index_row] = 1.0;
+                index_row += dims.row();
 
-                for _ in (lead + 1)..self.cols {
-                    unsafe {
-                        *data.get_unchecked_mut(index_row) /= lead_value;
-                    }
-                    index_row += self.rows;
+                for _ in (lead + 1)..dims.col() {
+                    data[index_row] /= lead_value;
+                    index_row += dims.row();
                 }
             }
 
             // Remove ROW from all other rows
-            for j in 0..self.rows {
+            for j in 0..dims.row() {
                 if j == row {
                     continue;
                 }
 
-                let mut index_j = index((j, lead));
-                let lead_multiplicator = unsafe { *data.get_unchecked(index_j) };
+                let mut index_j = index(j, lead);
+
+                let lead_multiplicator = data[index_j];
                 if lead_multiplicator == 0.0 {
                     continue;
                 }
-                unsafe {
-                    *data.get_unchecked_mut(index_j) = 0.0;
-                }
-                index_j += self.rows;
-                let mut index_row = index((row, lead + 1));
 
-                for _ in (lead + 1)..self.cols {
-                    unsafe {
-                        *data.get_unchecked_mut(index_j) -=
-                            *data.get_unchecked(index_row) * lead_multiplicator;
-                    }
-                    index_j += self.rows;
-                    index_row += self.rows;
+                data[index_j] = 0.0;
+                index_j += dims.row();
+                let mut index_row = index(row, lead + 1);
+
+                for _ in (lead + 1)..dims.col() {
+                    data[index_j] -= data[index_row] * lead_multiplicator;
+                    index_j += dims.row();
+                    index_row += dims.row();
                 }
             }
 
@@ -277,19 +271,25 @@ impl<'a> Matrix<'a> {
     }
     /// Returns the squared eculidean distance between the `row` and the slice `unit`
     #[inline]
-    pub fn distance_to_row(&self, row: usize, unit: &[f64]) -> f64 {
-        assert!(unit.len() == self.ncol());
-        assert!(row < self.nrow());
+    pub fn distance_to_row(&self, row: usize, unit: &[f64]) -> Option<f64> {
+        if unit.len() != self.ncol() || row >= self.nrow() {
+            return None;
+        }
 
-        self.row_iter(row)
+        let v = self
+            .row_iter(row)
             .zip(unit.iter())
-            .fold(0.0, |acc, (a, b)| acc + (a - b).powi(2))
+            .fold(0.0, |acc, (a, b)| acc + (a - b).powi(2));
+        Some(v)
     }
     /// Performes the calculation of self * multiplicand, where self is a matrix A, and multiplicand
     /// is a vector.
     #[inline]
-    pub fn prod_vec(&self, multiplicand: &[f64]) -> Vec<f64> {
-        assert!(multiplicand.len() == self.ncol());
+    pub fn prod_vec(&self, multiplicand: &[f64]) -> Option<Vec<f64>> {
+        if multiplicand.len() != self.ncol() {
+            return None;
+        }
+
         let data = self.data();
         let mut prod = vec![0.0; self.nrow()];
         let mut index: usize = 0;
@@ -301,21 +301,24 @@ impl<'a> Matrix<'a> {
             }
         }
 
-        prod
+        Some(prod)
     }
     /// Performes the calculation of matrices self * mat
     #[inline]
-    pub fn mult<'b>(&'a self, mat: &Matrix) -> Matrix<'b> {
-        assert!(self.ncol() == mat.nrow());
+    pub fn mult<'b>(&'a self, mat: &Matrix) -> Option<Matrix<'b>> {
+        if self.ncol() != mat.nrow() {
+            return None;
+        }
+
         let mut prod = Vec::<f64>::with_capacity(self.nrow() * mat.ncol());
 
         let mut index = 0usize;
         for _ in 0..mat.ncol() {
-            prod.extend_from_slice(&self.prod_vec(&mat.data()[index..(index + mat.nrow())]));
+            prod.extend_from_slice(&self.prod_vec(&mat.data()[index..(index + mat.nrow())])?);
             index += mat.nrow();
         }
 
-        Matrix::new(&prod, self.nrow())
+        Matrix::from_vec(prod, self.nrow())
     }
 }
 
@@ -323,52 +326,49 @@ impl<'a> Index<MatrixIndex> for Matrix<'a> {
     type Output = f64;
 
     #[inline]
-    fn index(&self, midx: MatrixIndex) -> &f64 {
-        unsafe { self.data().get_unchecked(self.matrix_index(midx)) }
+    fn index(&self, idx: MatrixIndex) -> &f64 {
+        let index = idx.to_index(self.dims()).unwrap();
+        &self.data()[index]
     }
 }
 impl<'a> IndexMut<MatrixIndex> for Matrix<'a> {
     #[inline]
-    fn index_mut(&mut self, midx: MatrixIndex) -> &mut f64 {
-        let idx = self.matrix_index(midx);
-        match self.data {
-            MatrixData::Mutable(ref mut v) => unsafe { v.get_unchecked_mut(idx) },
-            _ => {
-                self.to_mut();
-                self.index_mut(midx)
-            }
-        }
+    fn index_mut(&mut self, idx: MatrixIndex) -> &mut f64 {
+        let index = idx.to_index(self.dims()).unwrap();
+        &mut self.data_mut()[index]
     }
 }
-impl<'a> Clone for Matrix<'a> {
-    #[inline]
-    fn clone(&self) -> Self {
-        let slice = match self.data {
-            MatrixData::Mutable(ref v) => v.as_slice(),
-            MatrixData::Reference(v) => v,
-        };
 
-        Self {
-            rows: self.rows,
-            cols: self.cols,
-            data: MatrixData::Mutable(slice.to_vec()),
-        }
+impl<'a> Index<(usize, usize)> for Matrix<'a> {
+    type Output = f64;
+
+    #[inline]
+    fn index(&self, idx: (usize, usize)) -> &f64 {
+        let index = MatrixIndex::into_index(idx, self.dims()).unwrap();
+        &self.data()[index]
+    }
+}
+impl<'a> IndexMut<(usize, usize)> for Matrix<'a> {
+    #[inline]
+    fn index_mut(&mut self, idx: (usize, usize)) -> &mut f64 {
+        let index = MatrixIndex::into_index(idx, self.dims()).unwrap();
+        &mut self.data_mut()[index]
     }
 }
 
 pub struct MatrixIterator<'a> {
     iter: StepBy<Skip<Iter<'a, f64>>>,
-    dim: MatrixIndex,
+    dims: MatrixIndex,
     step: usize,
     count: usize,
 }
 impl<'a> MatrixIterator<'a> {
     #[inline]
-    pub fn dim(&self) -> MatrixIndex {
+    pub fn dims(&self) -> MatrixIndex {
         if self.step == 1 {
-            (self.dim.0, 1)
+            MatrixIndex(self.dims.row(), 1)
         } else {
-            (1, self.dim.1)
+            MatrixIndex(1, self.dims.col())
         }
     }
 }
@@ -384,9 +384,9 @@ impl<'a> ExactSizeIterator for MatrixIterator<'a> {
     #[inline]
     fn len(&self) -> usize {
         if self.step == 1 {
-            self.dim.0 - self.count
+            self.dims.row() - self.count
         } else {
-            self.dim.1 - self.count
+            self.dims.col() - self.count
         }
     }
 }

--- a/envisim_utils/tests/matrix.rs
+++ b/envisim_utils/tests/matrix.rs
@@ -1,34 +1,38 @@
 use envisim_test_utils::*;
-use envisim_utils::Matrix;
+use envisim_utils::{Matrix, MatrixIndex};
 
 const DATA_4_2: [f64; 8] = [
     0.0, 1.0, 2.0, 3.0, //
     10.0, 11.0, 12.0, 13.0, //
 ];
 
-fn matrix_new<'a>() -> (Matrix<'a>, Matrix<'a>) {
-    (Matrix::new(&DATA_4_2, 4), Matrix::from_ref(&DATA_4_2, 4))
+fn matrix_new<'a>() -> Matrix<'a> {
+    Matrix::new(&DATA_4_2, 4).unwrap()
+}
+
+#[test]
+fn borrow_vs_owned() {
+    let mm = matrix_new();
+    assert_eq!(mm.data(), DATA_4_2);
+    let mut rm = mm.clone();
+    rm.to_mut();
+    assert_eq!(rm.data(), DATA_4_2);
+    assert_eq!(mm.data(), rm.data());
 }
 
 #[test]
 fn operate_matrix() {
-    let (mm, rm) = matrix_new();
-    assert_eq!(mm.data(), DATA_4_2);
-    assert_eq!(rm.data(), DATA_4_2);
-
+    let mm = matrix_new();
     assert_eq!(mm.nrow(), 4);
-    assert_eq!(rm.nrow(), 4);
     assert_eq!(mm.ncol(), 2);
-    assert_eq!(rm.ncol(), 2);
-    assert_eq!(mm.dim(), (4, 2));
-    assert_eq!(rm.dim(), (4, 2));
+    assert_eq!(mm.dims(), MatrixIndex::new((4, 2)));
 
     assert_eq!(
         mm.row_iter(0).cloned().collect::<Vec<f64>>(),
         vec![0.0, 10.0]
     );
     assert_eq!(
-        rm.row_iter(1).cloned().collect::<Vec<f64>>(),
+        mm.row_iter(1).cloned().collect::<Vec<f64>>(),
         vec![1.0, 11.0]
     );
     assert_eq!(
@@ -36,60 +40,71 @@ fn operate_matrix() {
         vec![0.0, 1.0, 2.0, 3.0]
     );
     assert_eq!(
-        rm.col_iter(1).cloned().collect::<Vec<f64>>(),
+        mm.col_iter(1).cloned().collect::<Vec<f64>>(),
         vec![10.0, 11.0, 12.0, 13.0]
     );
 }
 
 #[test]
 fn distance_to_row() {
-    let (mm, rm) = matrix_new();
-    assert_eq!(mm.distance_to_row(0, &vec![10.0, 10.0]), 100.0 + 0.0);
-    assert_eq!(rm.distance_to_row(1, &vec![10.0, 10.0]), 81.0 + 1.0);
+    let mm = matrix_new();
+    assert_eq!(
+        mm.distance_to_row(0, &vec![10.0, 10.0]).unwrap(),
+        100.0 + 0.0
+    );
+    assert_eq!(
+        mm.distance_to_row(1, &vec![10.0, 10.0]).unwrap(),
+        81.0 + 1.0
+    );
 }
 
 #[test]
 fn prod_vec() {
-    let (mm, rm) = matrix_new();
+    let mm = matrix_new();
     assert_eq!(
-        mm.prod_vec(&vec![2.0, 3.0]),
+        mm.prod_vec(&vec![2.0, 3.0]).unwrap(),
         vec![30.0, 33.0 + 2.0, 36.0 + 4.0, 39.0 + 6.0]
     );
     assert_eq!(
-        rm.prod_vec(&vec![1.0, 2.0]),
+        mm.prod_vec(&vec![1.0, 2.0]).unwrap(),
         vec![20.0, 22.0 + 1.0, 24.0 + 2.0, 26.0 + 3.0]
     );
 }
 
 #[test]
 fn mult() {
-    let (mm, rm) = matrix_new();
-    let one_mat = Matrix::from_value(1.0, (2, 4));
-    let two_mat = Matrix::from_value(2.0, (2, 4));
-    assert_eq!(one_mat.mult(&mm).data(), vec![6.0, 6.0, 46.0, 46.0]);
-    assert_eq!(two_mat.mult(&rm).data(), vec![12.0, 12.0, 92.0, 92.0]);
+    let mm = matrix_new();
+    let one_mat = Matrix::from_value(1.0, (2, 4)).unwrap();
+    let two_mat = Matrix::from_value(2.0, (2, 4)).unwrap();
+    assert_eq!(
+        one_mat.mult(&mm).unwrap().data(),
+        vec![6.0, 6.0, 46.0, 46.0]
+    );
+    assert_eq!(
+        two_mat.mult(&mm).unwrap().data(),
+        vec![12.0, 12.0, 92.0, 92.0]
+    );
 }
 
 #[test]
 fn resize() {
-    let (mut mm, mut rm) = matrix_new();
+    let mut mm = matrix_new();
     mm.resize((2, 2));
-    rm.resize((2, 2));
-    assert_eq!(mm.dim(), (2, 2));
-    assert_eq!(rm.dim(), (2, 2));
+    assert_eq!(mm.dims(), MatrixIndex::new((2, 2)));
 }
 
 #[test]
 fn rref() {
-    let mut data1 = Matrix::new(
-        &[
+    let mut data1 = Matrix::from_vec(
+        vec![
             0.81, 0.46, 0.40, //
             0.54, 0.70, 0.08, //
             0.39, 0.42, 0.87, //
             0.64, 0.70, 0.32, //
         ],
         3,
-    );
+    )
+    .unwrap();
 
     data1.reduced_row_echelon_form();
     assert_fvec(&data1.data()[0..3], &vec![1.0, 0.0, 0.0]);

--- a/envisim_utils/tests/searcher.rs
+++ b/envisim_utils/tests/searcher.rs
@@ -3,14 +3,13 @@ use envisim_utils::kd_tree::*;
 use envisim_utils::{Matrix, Probabilities};
 use std::num::NonZeroUsize;
 
+const MATRIX_DATA: [f64; 10] = [
+    0.0, 1.0, 2.0, 13.0, 14.0, //
+    0.0, 10.0, 20.0, 30.0, 40.0, //
+];
+
 fn matrix_new<'a>() -> Matrix<'a> {
-    Matrix::new(
-        &[
-            0.0, 1.0, 2.0, 13.0, 14.0, //
-            0.0, 10.0, 20.0, 30.0, 40.0, //
-        ],
-        5,
-    )
+    Matrix::new(&MATRIX_DATA, 5).unwrap()
 }
 
 #[test]

--- a/rpkg/rsamplr/src/rust/src/matrix.rs
+++ b/rpkg/rsamplr/src/rust/src/matrix.rs
@@ -8,5 +8,5 @@ pub fn get_nrow(mat: &RealSexp) -> savvy::Result<usize> {
 }
 
 pub fn to_matrix(mat: &[f64], nrow: usize) -> Matrix {
-    Matrix::from_ref(mat, nrow)
+    Matrix::new(mat, nrow).unwrap()
 }

--- a/src/correlated_poisson.rs
+++ b/src/correlated_poisson.rs
@@ -14,9 +14,9 @@
 
 use crate::utils::SampleContainer;
 pub use crate::{SampleOptions, SamplingError};
-use envisim_utils::{
-    kd_tree::SearcherWeighted, random::RandomNumberGenerator, utils::usize_to_f64,
-};
+use envisim_utils::kd_tree::SearcherWeighted;
+use envisim_utils::random::RandomNumberGenerator;
+use envisim_utils::utils::usize_to_f64;
 
 struct VariantSequential {
     unit: usize,
@@ -413,7 +413,7 @@ where
 ///
 /// let mut rng = SmallRng::from_os_rng();
 /// let p = [0.2, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9];
-/// let m = Matrix::from_vec(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 10);
+/// let m = Matrix::from_vec(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 10).unwrap();
 /// let s = SampleOptions::new(&p)?.set_spreading(&m)?.sample(&mut rng, scps)?;
 ///
 /// assert_eq!(s.len(), 5);
@@ -429,9 +429,12 @@ where
 ///
 /// let mut rng = SmallRng::from_os_rng();
 /// let p = [0.2, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9];
-/// let m = Matrix::from_vec(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 10);
+/// let m = Matrix::from_vec(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 10).unwrap();
 /// let rv = [0.2; 10];
-/// let s = SampleOptions::new(&p)?.set_spreading(&m)?.set_random_values(&rv)?.sample(&mut rng, scps)?;
+/// let s = SampleOptions::new(&p)?
+///     .set_spreading(&m)?
+///     .set_random_values(&rv)?
+///     .sample(&mut rng, scps)?;
 ///
 /// assert_eq!(s.len(), 5);
 /// # Ok::<(), SamplingError>(())
@@ -460,7 +463,7 @@ where
 ///
 /// let mut rng = SmallRng::from_os_rng();
 /// let p = [0.2, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9];
-/// let m = Matrix::from_vec(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 10);
+/// let m = Matrix::from_vec(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 10).unwrap();
 /// let s = SampleOptions::new(&p)?.set_spreading(&m)?.sample(&mut rng, lcps)?;
 ///
 /// assert_eq!(s.len(), 5);
@@ -529,7 +532,7 @@ mod tests {
     #[test]
     fn scps_variant() -> Result<(), SamplingError> {
         let mut rng = SmallRng::seed_from_u64(42);
-        let data = Matrix::from_ref(&DATA_10_2, 10);
+        let data = Matrix::new(&DATA_10_2, 10).unwrap();
         let options = SampleOptions::new(&PROB_10_E)?.set_spreading(&data)?;
 
         let mut cps = VariantSpatial::new(&mut rng, &options)?;
@@ -551,7 +554,7 @@ mod tests {
     #[test]
     fn lcps_variant() -> Result<(), SamplingError> {
         let mut rng = SmallRng::seed_from_u64(42);
-        let data = Matrix::from_ref(&DATA_10_2, 10);
+        let data = Matrix::new(&DATA_10_2, 10).unwrap();
         let options = SampleOptions::new(&PROB_10_E)?.set_spreading(&data)?;
 
         let mut cps = VariantLocal::new(&mut rng, &options)?;

--- a/src/cube_method.rs
+++ b/src/cube_method.rs
@@ -15,7 +15,9 @@
 use crate::srs;
 use crate::utils::SampleContainer;
 pub use crate::{SampleOptions, SamplingError};
-use envisim_utils::{kd_tree::Searcher, random::RandomNumberGenerator, InputError, Matrix};
+use envisim_utils::kd_tree::Searcher;
+use envisim_utils::random::RandomNumberGenerator;
+use envisim_utils::{InputError, Matrix, MatrixIndex};
 use rustc_hash::FxSeededState;
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
@@ -63,13 +65,13 @@ where
     #[inline]
     fn new(container: SampleContainer<'a, R>, variant: T) -> Result<Self, SamplingError> {
         let balancing_data = container.options().check_balancing()?.balancing().unwrap();
-        let (b_nrow, b_ncol) = balancing_data.dim();
-        InputError::check_sizes(b_nrow, container.population_size())?;
-        let mut adjusted_data = Matrix::new(balancing_data.data(), b_nrow);
+        let b_dims = balancing_data.dims();
+        let mut adjusted_data = Matrix::new(balancing_data.data(), b_dims.row())
+            .ok_or_else(|| InputError::InvalidSize(b_dims.row(), container.population_size()))?;
 
-        for i in 0..b_nrow {
+        for i in 0..b_dims.row() {
             let p = container.probabilities()[i];
-            for j in 0..b_ncol {
+            for j in 0..b_dims.col() {
                 adjusted_data[(i, j)] /= p;
             }
         }
@@ -79,7 +81,7 @@ where
             variant,
             candidates: Vec::<usize>::with_capacity(20),
             adjusted_data,
-            candidate_data: Matrix::from_value(0.0, (b_ncol, b_ncol + 1)),
+            candidate_data: Matrix::from_value(0.0, (b_dims.col(), b_dims.col() + 1)).unwrap(),
         })
     }
     #[inline]
@@ -131,7 +133,10 @@ where
     #[inline]
     fn set_candidate_data(&mut self) -> &mut Self {
         let b_cols = self.candidates.len() - 1;
-        assert_eq!(self.candidate_data.dim(), (b_cols, self.candidates.len()));
+        assert_eq!(
+            self.candidate_data.dims(),
+            MatrixIndex(b_cols, self.candidates.len())
+        );
 
         for (i, &id) in self.candidates.iter().enumerate() {
             for j in 0..b_cols {
@@ -325,7 +330,7 @@ where
 /// let bal_m = Matrix::from_vec(vec![
 ///     0.2, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9,
 ///     0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9,
-/// ], 10);
+/// ], 10).unwrap();
 /// let s = SampleOptions::new(&p)?.set_balancing(&bal_m)?.sample(&mut rng, cube)?;
 ///
 /// assert_eq!(s.len(), 5);
@@ -360,7 +365,7 @@ where
 /// let bal_m = Matrix::from_vec(vec![
 ///     0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2,
 ///     0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9,
-/// ], 10);
+/// ], 10).unwrap();
 /// let strata = [0, 0, 0, 0, 0, 1, 1, 1, 1, 1];
 /// let options = SampleOptions::new(&p)?.set_balancing(&bal_m)?;
 /// let s = cube_stratified(&mut rng, &options, &strata)?;
@@ -401,11 +406,13 @@ where
             adjusted_data: Matrix::from_value(
                 0.0,
                 (balancing_data.nrow(), balancing_data.ncol() + 1),
-            ),
+            )
+            .unwrap(),
             candidate_data: Matrix::from_value(
                 0.0,
                 (balancing_data.ncol() + 1, balancing_data.ncol() + 2),
-            ),
+            )
+            .unwrap(),
         },
         strata: HashMap::<i64, Vec<usize>, FxSeededState>::with_capacity_and_hasher(
             probabilities.len() / 10,
@@ -432,8 +439,9 @@ where
 /// let bal_m = Matrix::from_vec(vec![
 ///     0.2, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9,
 ///     0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9,
-/// ], 10);
-/// let spr_m = Matrix::from_vec(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 10);
+/// ], 10).unwrap();
+/// let spr_m = Matrix::from_vec(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 10)
+///     .unwrap();
 /// let s = SampleOptions::new(&p)?
 ///     .set_balancing(&bal_m)?
 ///     .set_spreading(&spr_m)?
@@ -479,8 +487,9 @@ where
 /// let bal_m = Matrix::from_vec(vec![
 ///     0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2,
 ///     0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9,
-/// ], 10);
-/// let spr_m = Matrix::from_vec(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 10);
+/// ], 10).unwrap();
+/// let spr_m = Matrix::from_vec(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 10)
+///     .unwrap();
 /// let strata = [0, 0, 0, 0, 0, 1, 1, 1, 1, 1];
 /// let options = SampleOptions::new(&p)?.set_balancing(&bal_m)?.set_spreading(&spr_m)?;
 /// let s = local_cube_stratified(&mut rng, &options, &strata)?;
@@ -530,11 +539,13 @@ where
             adjusted_data: Matrix::from_value(
                 0.0,
                 (balancing_data.nrow(), balancing_data.ncol() + 1),
-            ),
+            )
+            .unwrap(),
             candidate_data: Matrix::from_value(
                 0.0,
                 (balancing_data.ncol() + 1, balancing_data.ncol() + 2),
-            ),
+            )
+            .unwrap(),
         },
         strata: HashMap::<i64, Vec<usize>, FxSeededState>::with_capacity_and_hasher(
             probabilities.len() / 10,
@@ -745,7 +756,7 @@ where
 /// mutated into rref.
 #[inline]
 fn find_vector_in_null_space(mat: &mut Matrix) -> Vec<f64> {
-    let (nrow, ncol) = mat.dim();
+    let MatrixIndex(nrow, ncol) = mat.dims();
     assert!(nrow > 0);
     assert!(nrow == ncol - 1);
 
@@ -800,23 +811,29 @@ mod tests {
 
     #[test]
     fn null() {
-        let mut mat1 = Matrix::new(
-            &[
-                1.0, 2.0, 3.0, 1.0, 5.0, 10.0, 1.0, 5.0, 10.0, 1.0, 5.0, 10.0,
+        let mut mat1 = Matrix::from_vec(
+            vec![
+                1.0, 2.0, 3.0, 1.0, //
+                5.0, 10.0, 1.0, 5.0, //
+                10.0, 1.0, 5.0, 10.0, //
             ],
             3,
-        );
+        )
+        .unwrap();
         mat1.reduced_row_echelon_form();
         assert!(mat1.data() == [1.0f64, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0]);
         let mat1_nullvec = find_vector_in_null_space(&mut mat1);
-        assert_fvec(&mat1.prod_vec(&mat1_nullvec), &[0.0, 0.0, 0.0]);
+        assert_fvec(&mat1.prod_vec(&mat1_nullvec).unwrap(), &[0.0, 0.0, 0.0]);
 
-        let mut mat2 = Matrix::new(
-            &[
-                1.0, 2.0, 3.0, 1.0, 5.0, 10.0, 10.0, 5.0, 1.0, 1.0, 5.0, 11.0,
+        let mut mat2 = Matrix::from_vec(
+            vec![
+                1.0, 2.0, 3.0, 1.0, //
+                5.0, 10.0, 10.0, 5.0, //
+                1.0, 1.0, 5.0, 11.0, //
             ],
             3,
-        );
+        )
+        .unwrap();
         mat2.reduced_row_echelon_form();
         assert!(&mat2.data()[0..9] == vec![1.0f64, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]);
         assert_fvec(
@@ -824,6 +841,6 @@ mod tests {
             &[-2.5, 1.833333333333333, 0.166666666666667],
         );
         let mat2_nullvec = find_vector_in_null_space(&mut mat2);
-        assert_fvec(&mat2.prod_vec(&mat2_nullvec), &[0.0, 0.0, 0.0]);
+        assert_fvec(&mat2.prod_vec(&mat2_nullvec).unwrap(), &[0.0, 0.0, 0.0]);
     }
 }

--- a/src/pivotal_method.rs
+++ b/src/pivotal_method.rs
@@ -457,7 +457,7 @@ where
 ///
 /// let mut rng = SmallRng::from_os_rng();
 /// let p = [0.2, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9];
-/// let m = Matrix::from_vec(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 10);
+/// let m = Matrix::from_vec(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 10).unwrap();
 /// let s = SampleOptions::new(&p)?.set_spreading(&m)?.sample(&mut rng, lpm_1)?;
 ///
 /// assert_eq!(s.len(), 5);
@@ -487,7 +487,7 @@ where
 ///
 /// let mut rng = SmallRng::from_os_rng();
 /// let p = [0.2, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9];
-/// let m = Matrix::from_vec(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 10);
+/// let m = Matrix::from_vec(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 10).unwrap();
 /// let s = SampleOptions::new(&p)?.set_spreading(&m)?.sample(&mut rng, lpm_1s)?;
 ///
 /// assert_eq!(s.len(), 5);
@@ -514,7 +514,7 @@ where
 ///
 /// let mut rng = SmallRng::from_os_rng();
 /// let p = [0.2, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9];
-/// let m = Matrix::from_vec(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 10);
+/// let m = Matrix::from_vec(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 10).unwrap();
 /// let s = SampleOptions::new(&p)?.set_spreading(&m)?.sample(&mut rng, lpm_1)?;
 ///
 /// assert_eq!(s.len(), 5);
@@ -547,7 +547,7 @@ where
 ///
 /// let mut rng = SmallRng::from_os_rng();
 /// let p = [0.2, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9];
-/// let m = Matrix::from_vec(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 10);
+/// let m = Matrix::from_vec(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 10).unwrap();
 /// let options = SampleOptions::new(&p)?.set_spreading(&m)?;
 /// let sizes = [3, 2];
 /// let s = hierarchical_lpm_2(&mut rng, &options, &sizes)?;

--- a/src/sample_options.rs
+++ b/src/sample_options.rs
@@ -12,7 +12,8 @@
 
 use crate::SamplingError;
 use envisim_utils::kd_tree::{midpoint_slide, FindSplit, Node, TreeBuilder};
-use envisim_utils::{random::RandomNumberGenerator, InputError, Matrix, Probabilities};
+use envisim_utils::random::RandomNumberGenerator;
+use envisim_utils::{InputError, Matrix, Probabilities};
 use std::num::NonZeroUsize;
 
 pub struct AuxiliariesOptions<'a> {

--- a/tests/correlated_poisson.rs
+++ b/tests/correlated_poisson.rs
@@ -18,7 +18,7 @@ fn test_cps() -> Result<(), SamplingError> {
 fn test_scps() -> Result<(), SamplingError> {
     let mut rng = SmallRng::seed_from_u64(42);
     let p = &PROB_10_U;
-    let data = Matrix::from_ref(&DATA_10_2, 10);
+    let data = Matrix::new(&DATA_10_2, 10).unwrap();
     let opts = SampleOptions::new(p)?.set_spreading(&data)?;
 
     test_wor(scps, &mut rng, &opts, p, 1e-2, 100000)
@@ -28,7 +28,7 @@ fn test_scps() -> Result<(), SamplingError> {
 fn test_lcps() -> Result<(), SamplingError> {
     let mut rng = SmallRng::seed_from_u64(42);
     let p = &PROB_10_U;
-    let data = Matrix::from_ref(&DATA_10_2, 10);
+    let data = Matrix::new(&DATA_10_2, 10).unwrap();
     let opts = SampleOptions::new(p)?.set_spreading(&data)?;
 
     test_wor(lcps, &mut rng, &opts, p, 1e-2, 100000)

--- a/tests/cube_method.rs
+++ b/tests/cube_method.rs
@@ -17,7 +17,7 @@ const BAL_DATA_10_1_P: [f64; 20] = [
 fn test_cube() -> Result<(), SamplingError> {
     let mut rng = SmallRng::seed_from_u64(42);
     let p = &PROB_10_U;
-    let baldata = Matrix::from_ref(&BAL_DATA_10_1_P, 10);
+    let baldata = Matrix::new(&BAL_DATA_10_1_P, 10).unwrap();
     let opts = SampleOptions::new(p)?.set_balancing(&baldata)?;
 
     test_wor(cube, &mut rng, &opts, p, 1e-2, 100000)
@@ -27,8 +27,8 @@ fn test_cube() -> Result<(), SamplingError> {
 fn test_lcube() -> Result<(), SamplingError> {
     let mut rng = SmallRng::seed_from_u64(42);
     let p = &PROB_10_U;
-    let data = Matrix::from_ref(&DATA_10_2, 10);
-    let baldata = Matrix::from_ref(&BAL_DATA_10_1_P, 10);
+    let data = Matrix::new(&DATA_10_2, 10).unwrap();
+    let baldata = Matrix::new(&BAL_DATA_10_1_P, 10).unwrap();
     let opts = SampleOptions::new(p)?
         .set_balancing(&baldata)?
         .set_spreading(&data)?;
@@ -43,7 +43,7 @@ fn test_cube_stratified() -> Result<(), SamplingError> {
 
     let mut rng = SmallRng::seed_from_u64(42);
     let probs = &PROB_10_E;
-    let baldata = Matrix::from_ref(&BAL_DATA_10_1, 10);
+    let baldata = Matrix::new(&BAL_DATA_10_1, 10).unwrap();
     let opts = SampleOptions::new(probs)?.set_balancing(&baldata)?;
 
     {
@@ -74,8 +74,8 @@ fn test_lcube_stratified() -> Result<(), SamplingError> {
 
     let mut rng = SmallRng::seed_from_u64(42);
     let probs = &PROB_10_U;
-    let data = Matrix::from_ref(&DATA_10_2, 10);
-    let baldata = Matrix::from_ref(&BAL_DATA_10_1, 10);
+    let data = Matrix::new(&DATA_10_2, 10).unwrap();
+    let baldata = Matrix::new(&BAL_DATA_10_1, 10).unwrap();
     let opts = SampleOptions::new(probs)?
         .set_balancing(&baldata)?
         .set_spreading(&data)?;

--- a/tests/pivotal_method.rs
+++ b/tests/pivotal_method.rs
@@ -27,7 +27,7 @@ fn test_rpm() -> Result<(), SamplingError> {
 fn test_lpm1() -> Result<(), SamplingError> {
     let mut rng = SmallRng::seed_from_u64(42);
     let p = &PROB_10_U;
-    let data = Matrix::from_ref(&DATA_10_2, 10);
+    let data = Matrix::new(&DATA_10_2, 10).unwrap();
     let opts = SampleOptions::new(p)?.set_spreading(&data)?;
 
     test_wor(lpm_1, &mut rng, &opts, p, 1e-2, 12000)
@@ -37,7 +37,7 @@ fn test_lpm1() -> Result<(), SamplingError> {
 fn test_lpm1s() -> Result<(), SamplingError> {
     let mut rng = SmallRng::seed_from_u64(42);
     let p = &PROB_10_U;
-    let data = Matrix::from_ref(&DATA_10_2, 10);
+    let data = Matrix::new(&DATA_10_2, 10).unwrap();
     let opts = SampleOptions::new(p)?.set_spreading(&data)?;
 
     test_wor(lpm_1s, &mut rng, &opts, p, 1e-2, 10000)
@@ -47,7 +47,7 @@ fn test_lpm1s() -> Result<(), SamplingError> {
 fn test_lpm2() -> Result<(), SamplingError> {
     let mut rng = SmallRng::seed_from_u64(42);
     let p = &PROB_10_U;
-    let data = Matrix::from_ref(&DATA_10_2, 10);
+    let data = Matrix::new(&DATA_10_2, 10).unwrap();
     let opts = SampleOptions::new(p)?.set_spreading(&data)?;
 
     test_wor(lpm_2, &mut rng, &opts, p, 1e-2, 12000)
@@ -60,7 +60,7 @@ fn test_hlpm2() -> Result<(), SamplingError> {
 
     let mut rng = SmallRng::seed_from_u64(42);
     let probs = &PROB_10_U;
-    let data = Matrix::from_ref(&DATA_10_2, 10);
+    let data = Matrix::new(&DATA_10_2, 10).unwrap();
     let opts = SampleOptions::new(probs)?.set_spreading(&data)?;
 
     {


### PR DESCRIPTION
- Matrix use std::borrow.
- MatrixIndex as struct instead of tuple.
- Most Matrix methods are allowed to fail by returning Option.
- Matrix::dim renamed to Matrix::dims