### PR TITLE
(fix) generic iterator

### DIFF
--- a/envisim_estimate/src/spatial_balance.rs
+++ b/envisim_estimate/src/spatial_balance.rs
@@ -20,6 +20,7 @@ use envisim_utils::matrix::{
     MatrixDims,
     MatrixRef,
     PointSet,
+    RawData,
 };
 pub use envisim_utils::sampling_options::SamplingOptions;
 use envisim_utils::sampling_options::{
@@ -277,7 +278,7 @@ where
 
     norm_matrix.reduced_row_echelon_form();
     let inv_matrix = Matrix::new(
-        norm_matrix.data()[norm_matrix.nrow().get().pow(2)..].to_vec(),
+        norm_matrix.data().data()[norm_matrix.nrow().get().pow(2)..].to_vec(),
         norm_matrix.nrow(),
     )
     .expect("dimenions to be correct");
@@ -288,8 +289,7 @@ where
             .mul_mat(&inv_matrix)
             .expect("dimensions to match")
             .mul_mat(&MatrixRef::new(vec, cols).expect("cols = vec.len"))
-            .expect("dimensions to match")
-            .data()[0]
+            .expect("dimensions to match")[(0, 0)]
     });
 
     Ok((result

--- a/envisim_samplr/src/cube_method/utils.rs
+++ b/envisim_samplr/src/cube_method/utils.rs
@@ -104,6 +104,7 @@ pub fn find_vector_in_null_space(mat: &mut Matrix<f64>) -> Vec<f64> {
 
 #[cfg(test)]
 mod tests {
+    use envisim_utils::matrix::RawData;
     use envisim_utils::test_utils::*;
 
     use super::*;
@@ -121,14 +122,14 @@ mod tests {
         .unwrap();
         mat1.reduced_row_echelon_form();
         assert!(
-            mat1.data()
+            mat1.data().data()
                 == [
                     1.0f64, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0
                 ]
         );
         let mat1_nullvec = find_vector_in_null_space(&mut mat1);
         assert_fvec(
-            &mat1.mul_vec(&mat1_nullvec).unwrap().data(),
+            &mat1.mul_vec(&mat1_nullvec).unwrap().data().data(),
             &[0.0, 0.0, 0.0],
         );
 
@@ -142,14 +143,14 @@ mod tests {
         )
         .unwrap();
         mat2.reduced_row_echelon_form();
-        assert!(&mat2.data()[0..9] == vec![1.0f64, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]);
+        assert!(&mat2.data().data()[0..9] == vec![1.0f64, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]);
         assert_fvec(
-            &mat2.data()[9..12], // col 3
+            &mat2.data().data()[9..12], // col 3
             &[-2.5, 1.833333333333333, 0.166666666666667],
         );
         let mat2_nullvec = find_vector_in_null_space(&mut mat2);
         assert_fvec(
-            &mat2.mul_vec(&mat2_nullvec).unwrap().data(),
+            &mat2.mul_vec(&mat2_nullvec).unwrap().data().data(),
             &[0.0, 0.0, 0.0],
         );
     }

--- a/envisim_utils/CHANGELOG.md
+++ b/envisim_utils/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Made `Matrix` generic over `Number`. `Matrix` is now a type alias for `MatrixBase`, and represents an owned matrix. The type alias for a reference matrix is `MatrixRef`.
-- Refactored `MatrixIterator`.
+- Removed `MatrixIterator` in favour of slice implementation.
 - Removed `Node`'s dependency on data, and transformed it into an enum, replacing `NodeKind`.
 - Changed `TreeSearcher` trait
 - Refactored `SamplingOptions` to follow the typestate pattern (again). The types are concrete members of the options object, and unset members are represented by `()`. In addition to the probability specification, spreading and balancing are represented in this pattern. Coordination is now not set through `SamplingOptions`, but still provided as a helper through `CoordinationOptions`.

--- a/envisim_utils/src/matrix/mod.rs
+++ b/envisim_utils/src/matrix/mod.rs
@@ -95,40 +95,34 @@ where
     /// Returns `None`  if the coordinates are invalid.
     #[must_use]
     #[inline]
-    pub fn get<C>(&self, coord: C) -> Option<N>
+    pub fn get<C>(&self, coord: C) -> Option<&N>
     where
         C: Into<MatrixCoord>,
         N: Copy,
     {
         let coord = coord.into();
-        self.dims.contains(coord).then(|| self[coord])
+        self.dims.contains(coord).then(|| &self[coord])
     }
     /// Returns an iterator of the elements in a row.
     /// Returns `None` if the row is invalid.
     #[must_use]
     #[inline]
-    pub fn row_iter(&self, row: usize) -> Option<impl ExactSizeIterator<Item = N>>
-    where
-        N: Copy,
-    {
+    pub fn row_iter(&self, row: usize) -> Option<impl ExactSizeIterator<Item = &N>> {
         let nrow = self.nrow().get();
         self.dims()
             .contains_row(row)
-            .then(|| self.internal_data()[row..].iter().step_by(nrow).copied())
+            .then(|| self.internal_data()[row..].iter().step_by(nrow))
     }
     /// Returns an iterator of the elements in a column.
     /// Returns `None` if the column is invalid.
     #[must_use]
     #[inline]
-    pub fn col_iter(&self, col: usize) -> Option<impl ExactSizeIterator<Item = N>>
-    where
-        N: Copy,
-    {
+    pub fn col_iter(&self, col: usize) -> Option<impl ExactSizeIterator<Item = &N>> {
         let nrow = self.nrow().get();
         let start = nrow * col;
         self.dims()
             .contains_col(col)
-            .then(|| self.internal_data()[start..(start + nrow)].iter().copied())
+            .then(|| self.internal_data()[start..(start + nrow)].iter())
     }
     /// Multiplies the matrix by a column vector.
     /// Returns `None` if the column vector length does not match the number of columns in the
@@ -253,7 +247,7 @@ where
     /// Returns `None` if the coordinates are oob.
     #[expect(clippy::renamed_function_params, reason = "a matrix has rows, not ids")]
     #[inline]
-    fn try_coord(&self, row: usize, col: usize) -> Option<N> { self.get((row, col)) }
+    fn try_coord(&self, row: usize, col: usize) -> Option<N> { self.get((row, col)).copied() }
     /// Returns the squared euclidean distance between rows `id_a` and `id_b`.
     /// Panics on oob.
     #[inline]
@@ -304,6 +298,38 @@ impl<N> Matrix<N> {
             data: OwnedMatrixData::new(vec![data; dims.len().get()]),
             dims,
         }
+    }
+    /// Returns a mutable reference to the element at a specific coordinate.
+    /// Returns `None`  if the coordinates are invalid.
+    #[must_use]
+    #[inline]
+    pub fn get_mut<C>(&mut self, coord: C) -> Option<&mut N>
+    where
+        C: Into<MatrixCoord>,
+    {
+        let coord = coord.into();
+        self.dims.contains(coord).then(|| &mut self[coord])
+    }
+    /// Returns a mutable iterator of the elements in a row.
+    /// Returns `None` if the row is invalid.
+    #[must_use]
+    #[inline]
+    pub fn row_iter_mut(&mut self, row: usize) -> Option<impl ExactSizeIterator<Item = &mut N>> {
+        let nrow = self.nrow().get();
+        self.dims()
+            .contains_row(row)
+            .then(|| self.data.data[row..].iter_mut().step_by(nrow))
+    }
+    /// Returns a mutable iterator of the elements in a column.
+    /// Returns `None` if the column is invalid.
+    #[must_use]
+    #[inline]
+    pub fn col_iter_mut(&mut self, col: usize) -> Option<impl ExactSizeIterator<Item = &mut N>> {
+        let nrow = self.nrow().get();
+        let start = nrow * col;
+        self.dims()
+            .contains_col(col)
+            .then(|| self.data.data[start..(start + nrow)].iter_mut())
     }
     /// Resizes the matrix.
     /// Does not respect data on expansion.
@@ -542,8 +568,8 @@ mod tests {
         assert_eq!(m.dims().rows, nz(3));
 
         // get() method
-        assert_eq!(m.get((0, 0)), Some(1.0));
-        assert_eq!(m.get((2, 1)), Some(6.0));
+        assert_eq!(m.get((0, 0)), Some(&1.0));
+        assert_eq!(m.get((2, 1)), Some(&6.0));
         assert_eq!(m.get((3, 0)), None); // Out of bounds
     }
 
@@ -580,16 +606,16 @@ mod tests {
         // Row Iterator for row 1: [2.0, 5.0]
         let mut row_iter = m.row_iter(1).unwrap();
         assert_eq!(row_iter.len(), 2);
-        assert_eq!(row_iter.next(), Some(2.0));
-        assert_eq!(row_iter.next(), Some(5.0));
+        assert_eq!(row_iter.next(), Some(&2.0));
+        assert_eq!(row_iter.next(), Some(&5.0));
         assert_eq!(row_iter.next(), None);
 
         // Column Iterator for col 1: [4.0, 5.0, 6.0]
         let mut col_iter = m.col_iter(1).unwrap();
         assert_eq!(col_iter.len(), 3);
-        assert_eq!(col_iter.next(), Some(4.0));
-        assert_eq!(col_iter.next(), Some(5.0));
-        assert_eq!(col_iter.next(), Some(6.0));
+        assert_eq!(col_iter.next(), Some(&4.0));
+        assert_eq!(col_iter.next(), Some(&5.0));
+        assert_eq!(col_iter.next(), Some(&6.0));
         assert_eq!(col_iter.next(), None);
 
         // Invalid indices

--- a/envisim_utils/src/matrix/mod.rs
+++ b/envisim_utils/src/matrix/mod.rs
@@ -68,7 +68,7 @@ where
     #[inline]
     pub fn to_matrixref(&self) -> MatrixRef<'_, N> {
         MatrixRef {
-            data: self.data().into(),
+            data: self.internal_data().into(),
             dims: self.dims(),
         }
     }
@@ -79,14 +79,18 @@ where
         N: Copy,
     {
         Matrix {
-            data: self.data().to_vec().into(),
+            data: self.internal_data().to_vec().into(),
             dims: self.dims(),
         }
     }
+    /// Returns a reference to the underlying data
+    #[must_use]
+    #[inline]
+    pub fn data(&self) -> &T { &self.data }
     /// Returns a reference to the underlying data as a slice.
     #[must_use]
     #[inline]
-    pub fn data(&self) -> &[N] { self.data.data() }
+    fn internal_data(&self) -> &[N] { self.data().data() }
     /// Returns the element at a specific coordinate.
     /// Returns `None`  if the coordinates are invalid.
     #[must_use]
@@ -103,15 +107,28 @@ where
     /// Returns `None` if the row is invalid.
     #[must_use]
     #[inline]
-    pub fn row_iter(&self, row: usize) -> Option<MatrixIterator<'_, T, N>> {
-        MatrixIterator::new(self, row, false)
+    pub fn row_iter(&self, row: usize) -> Option<impl ExactSizeIterator<Item = N>>
+    where
+        N: Copy,
+    {
+        let nrow = self.nrow().get();
+        self.dims()
+            .contains_row(row)
+            .then(|| self.internal_data()[row..].iter().step_by(nrow).copied())
     }
     /// Returns an iterator of the elements in a column.
     /// Returns `None` if the column is invalid.
     #[must_use]
     #[inline]
-    pub fn col_iter(&self, col: usize) -> Option<MatrixIterator<'_, T, N>> {
-        MatrixIterator::new(self, col, true)
+    pub fn col_iter(&self, col: usize) -> Option<impl ExactSizeIterator<Item = N>>
+    where
+        N: Copy,
+    {
+        let nrow = self.nrow().get();
+        let start = nrow * col;
+        self.dims()
+            .contains_col(col)
+            .then(|| self.internal_data()[start..(start + nrow)].iter().copied())
     }
     /// Multiplies the matrix by a column vector.
     /// Returns `None` if the column vector length does not match the number of columns in the
@@ -129,7 +146,7 @@ where
         let mut index = 0;
         for mul in rhs {
             for pr in &mut product {
-                *pr += *mul * self.data()[index];
+                *pr += *mul * self.internal_data()[index];
                 index += 1;
             }
         }
@@ -153,10 +170,10 @@ where
         // Multiply self by each column in rhs
         for _ in 0..rhs.ncol().get() {
             // Take rhs column
-            let rhs_col = &rhs.data()[index..(index + rhs.nrow().get())];
+            let rhs_col = &rhs.internal_data()[index..(index + rhs.nrow().get())];
             // Result
             let temp_column_res = self.mul_vec(rhs_col)?;
-            product.extend_from_slice(temp_column_res.data());
+            product.extend_from_slice(temp_column_res.internal_data());
             index += rhs.nrow().get();
         }
         Matrix::new(product, self.nrow())
@@ -186,7 +203,7 @@ where
             .into()
             .to_linear(self.dims)
             .expect("index to be valid for the matrix");
-        &self.data()[index]
+        &self.internal_data()[index]
     }
 }
 impl<T, N> From<&MatrixBase<T, N>> for Matrix<N>
@@ -230,7 +247,7 @@ where
     #[inline]
     fn coord(&self, row: usize, col: usize) -> N {
         let idx = row + col * self.dims.rows.get();
-        self.data()[idx]
+        self.internal_data()[idx]
     }
     /// Returns the element at coordinates `(row, col)`.
     /// Returns `None` if the coordinates are oob.
@@ -248,7 +265,7 @@ where
         let idx_diff = id_a.abs_diff(id_b);
         let mut sum = N::zero();
         for _ in 0..self.ncol().get() {
-            let diff = self.data()[idx] - self.data()[idx + idx_diff];
+            let diff = self.internal_data()[idx] - self.internal_data()[idx + idx_diff];
             sum += diff * diff;
             idx += self.nrow().get();
         }
@@ -259,79 +276,6 @@ where
     #[inline]
     fn try_sq_distance_between(&self, id_a: usize, id_b: usize) -> Option<N> {
         (self.exists(id_a) && self.exists(id_b)).then(|| self.sq_distance_between(id_a, id_b))
-    }
-}
-
-/// An iterator over a row in a matrix
-#[must_use]
-pub struct MatrixIterator<'bmat, T, N = <T as RawData>::Elem>
-where
-    T: RawData<Elem = N>,
-{
-    /// A reference to the matrix
-    data: &'bmat MatrixBase<T, N>,
-    /// The current coordinates of the iterator
-    coord: MatrixCoord,
-    /// If `true`, the iterator is a column iterator
-    is_column_iter: bool,
-}
-impl<'bmat, T, N> MatrixIterator<'bmat, T, N>
-where
-    T: RawData<Elem = N>,
-{
-    /// Constructs a new matrix iterator
-    #[inline]
-    fn new(matrix: &'bmat MatrixBase<T, N>, start: usize, iterate_column: bool) -> Option<Self> {
-        if iterate_column {
-            if !matrix.dims().contains_col(start) {
-                return None;
-            }
-            Some(Self {
-                data: matrix,
-                coord: (0, start).into(),
-                is_column_iter: true,
-            })
-        } else {
-            if !matrix.dims().contains_row(start) {
-                return None;
-            }
-            Some(Self {
-                data: matrix,
-                coord: (start, 0).into(),
-                is_column_iter: false,
-            })
-        }
-    }
-}
-impl<T, N> Iterator for MatrixIterator<'_, T, N>
-where
-    T: RawData<Elem = N>,
-    N: Copy,
-{
-    type Item = N;
-    #[inline]
-    fn next(&mut self) -> Option<N> {
-        let val = self.data.get(self.coord);
-        if self.is_column_iter {
-            self.coord.row += 1;
-        } else {
-            self.coord.col += 1;
-        }
-        val
-    }
-}
-impl<T, N> ExactSizeIterator for MatrixIterator<'_, T, N>
-where
-    T: RawData<Elem = N>,
-    N: Copy,
-{
-    #[inline]
-    fn len(&self) -> usize {
-        if self.is_column_iter {
-            self.data.nrow().get() - self.coord.row
-        } else {
-            self.data.ncol().get() - self.coord.col
-        }
     }
 }
 


### PR DESCRIPTION
Removed `MatrixIterator` in favour of slice implementation. col_iter and row_iter contract now only guarantees an exactsizeiterator.