### PR TITLE
(feat) Random number generation use rand-like traits

### DIFF
--- a/envisim_samplr/src/correlated_poisson.rs
+++ b/envisim_samplr/src/correlated_poisson.rs
@@ -38,7 +38,11 @@ use envisim_utils::probabilities::{
     FloatProbabilities,
     ProbabilityStore,
 };
-use envisim_utils::random::RandomNumberGenerator;
+use envisim_utils::random::{
+    FloatRng,
+    Rand,
+    random_element,
+};
 use envisim_utils::sample_controller::{
     SampleController,
     UnitRemoving,
@@ -61,14 +65,14 @@ use crate::error::SamplingResult;
 pub trait CorrelatedPoissonStrategy<TREE> {
     fn random_value<R>(&mut self, rng: &mut R, id: usize) -> f64
     where
-        R: RandomNumberGenerator;
+        R: FloatRng;
     fn select_unit<R>(
         &mut self,
         controller: &mut SampleController<FloatProbabilities, TREE>,
         rng: &mut R,
     ) -> Option<usize>
     where
-        R: RandomNumberGenerator;
+        R: FloatRng;
     fn update_probabilities(
         &mut self,
         controller: &mut SampleController<FloatProbabilities, TREE>,
@@ -99,7 +103,7 @@ where
     #[inline]
     fn sample<R>(&mut self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         self.run(rng);
         self.controller.sample_vec()
@@ -108,7 +112,7 @@ where
     #[inline]
     fn run<R>(&mut self, rng: &mut R)
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         while let Some(id) = self.strategy.select_unit(&mut self.controller, rng) {
             let (p, q) = self.decide_unit(rng, id);
@@ -121,7 +125,7 @@ where
     #[must_use]
     fn decide_unit<R>(&mut self, rng: &mut R, id: usize) -> (f64, f64)
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         let probability = self.controller.probabilities().get(id);
         let mut quota = probability;
@@ -192,7 +196,7 @@ impl CorrelatedPoissonStrategy<()> for SequentialStrategy<'_> {
     #[inline]
     fn random_value<R>(&mut self, rng: &mut R, id: usize) -> f64
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         self.random_values.get_or(id, rng)
     }
@@ -203,7 +207,7 @@ impl CorrelatedPoissonStrategy<()> for SequentialStrategy<'_> {
         _rng: &mut R,
     ) -> Option<usize>
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         // Tempting to use controller.indices().last(), but order is not guaranteed as swap_remove
         // might move a unit forward in the indices.list().
@@ -384,7 +388,7 @@ where
     #[inline]
     fn random_value<R>(&mut self, rng: &mut R, id: usize) -> f64
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         self.random_values.get_or(id, rng)
     }
@@ -396,7 +400,7 @@ where
         rng: &mut R,
     ) -> Option<usize>
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         if controller.indices().is_empty() {
             return None;
@@ -468,9 +472,9 @@ where
     #[inline]
     fn random_value<R>(&mut self, rng: &mut R, _id: usize) -> f64
     where
-        R: RandomNumberGenerator,
+        R: Rand<f64>,
     {
-        rng.rf64()
+        rng.rand()
     }
     #[must_use]
     #[inline]
@@ -480,7 +484,7 @@ where
         rng: &mut R,
     ) -> Option<usize>
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         if controller.indices().len() <= 1 {
             return controller.indices().first();
@@ -521,7 +525,7 @@ where
             i += 1;
         }
 
-        rng.relement(&self.candidates).copied()
+        random_element(rng, &self.candidates).copied()
     }
     #[inline]
     fn update_probabilities(
@@ -543,7 +547,7 @@ pub trait CorrelatedPoissonSampling {
     /// ```
     /// # use envisim_samplr::*;
     /// # use envisim_utils::random::*;
-    /// let mut rng = SmallRng::try_sys_rng().unwrap();
+    /// let mut rng = try_sys_rng().unwrap();
     /// let p: Vec<f64> = vec![0.2, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9];
     /// let s = SamplingOptions::new(p.into())?.cps(&mut rng);
     /// assert_eq!(s.len(), 5);
@@ -552,7 +556,7 @@ pub trait CorrelatedPoissonSampling {
     #[must_use]
     fn cps<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator;
+        R: FloatRng;
     /// Draw a sample using the (sequential) correlated poisson sampling method.
     /// A variant of the cps where unit competes in order.
     ///
@@ -562,7 +566,7 @@ pub trait CorrelatedPoissonSampling {
     /// ```
     /// # use envisim_samplr::*;
     /// # use envisim_utils::random::*;
-    /// let mut rng = SmallRng::try_sys_rng().unwrap();
+    /// let mut rng = try_sys_rng().unwrap();
     /// let p: Vec<f64> = vec![0.2, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9];
     /// let rv: Vec<f64> = vec![0.2; 10];
     /// let s = SamplingOptions::new(p.into())?.cps_coord(&mut rng, rv)?;
@@ -576,7 +580,7 @@ pub trait CorrelatedPoissonSampling {
     /// Returns an error if fewer than `population_size` random values is provided.
     fn cps_coord<'bcoord, R, C>(&self, rng: &mut R, random_values: C) -> SamplingResult<Vec<usize>>
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
         C: Into<CoordinationOptions<'bcoord>>;
 }
 pub trait SpatiallyCorrelatedPoissonSampling<P>
@@ -591,7 +595,7 @@ where
     /// # use envisim_samplr::*;
     /// # use envisim_utils::random::*;
     /// # use envisim_utils::matrix::Matrix;
-    /// let mut rng = SmallRng::try_sys_rng().unwrap();
+    /// let mut rng = try_sys_rng().unwrap();
     /// let p: Vec<f64> = vec![0.2, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9];
     /// let m = Matrix::new(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 10).unwrap();
     /// let s = SamplingOptions::new(p.into())?.set_spreading(m)?.scps(&mut rng);
@@ -601,7 +605,7 @@ where
     #[must_use]
     fn scps<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator;
+        R: FloatRng;
     /// Draw a sample using the spatially correlated poisson sampling method.
     /// The sample is spatially balanced on the provided auxilliary variables in `data`.
     ///
@@ -612,7 +616,7 @@ where
     /// # use envisim_samplr::correlated_poisson::*;
     /// # use envisim_utils::random::*;
     /// # use envisim_utils::matrix::Matrix;
-    /// let mut rng = SmallRng::try_sys_rng().unwrap();
+    /// let mut rng = try_sys_rng().unwrap();
     /// let p: Vec<f64> = vec![0.2, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9];
     /// let m = Matrix::new(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 10).unwrap();
     /// let rv: Vec<f64> = vec![0.2; 10];
@@ -631,7 +635,7 @@ where
         random_values: C,
     ) -> SamplingResult<Vec<usize>>
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
         C: Into<CoordinationOptions<'bcoord>>;
     /// Draw a sample using the locally correlated poisson sampling method.
     /// The sample is spatially balanced on the provided auxilliary variables in `data`.
@@ -641,7 +645,7 @@ where
     /// # use envisim_samplr::*;
     /// # use envisim_utils::random::*;
     /// # use envisim_utils::matrix::Matrix;
-    /// let mut rng = SmallRng::try_sys_rng().unwrap();
+    /// let mut rng = try_sys_rng().unwrap();
     /// let p: Vec<f64> = vec![0.2, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9];
     /// let m = Matrix::new(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 10).unwrap();
     /// let s = SamplingOptions::new(p.into())?.set_spreading(m)?.lcps(&mut rng);
@@ -651,7 +655,7 @@ where
     #[must_use]
     fn lcps<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator;
+        R: FloatRng;
 }
 impl<PS, AUX, BAL> CorrelatedPoissonSampling for SamplingOptions<PS, AUX, BAL>
 where
@@ -660,14 +664,14 @@ where
     #[inline]
     fn cps<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         SequentialStrategy::new(self).sample(rng)
     }
     #[inline]
     fn cps_coord<'bcoord, R, C>(&self, rng: &mut R, random_values: C) -> SamplingResult<Vec<usize>>
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
         C: Into<CoordinationOptions<'bcoord>>,
     {
         Ok(SequentialStrategy::new_coord(self, random_values)?.sample(rng))
@@ -682,14 +686,14 @@ where
     #[inline]
     fn scps<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         SpatialStrategy::new(self).sample(rng)
     }
     #[inline]
     fn scps_coord<'bcoord, R, C>(&self, rng: &mut R, random_values: C) -> SamplingResult<Vec<usize>>
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
         C: Into<CoordinationOptions<'bcoord>>,
     {
         Ok(SpatialStrategy::new_coord(self, random_values)?.sample(rng))
@@ -697,7 +701,7 @@ where
     #[inline]
     fn lcps<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         LocalStrategy::new(self).sample(rng)
     }
@@ -738,7 +742,7 @@ mod tests {
         id: usize,
     ) -> (f64, f64)
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
         S: CorrelatedPoissonStrategy<TREE>,
         SampleController<FloatProbabilities, TREE>: UnitRemoving,
     {

--- a/envisim_samplr/src/cube_method/cube.rs
+++ b/envisim_samplr/src/cube_method/cube.rs
@@ -33,7 +33,11 @@ use envisim_utils::probabilities::{
     FloatProbabilities,
     ProbabilityStore,
 };
-use envisim_utils::random::RandomNumberGenerator;
+use envisim_utils::random::{
+    FloatRng,
+    Rand,
+    random_weighted,
+};
 use envisim_utils::sample_controller::{
     SampleController,
     UnitRemoving,
@@ -60,7 +64,7 @@ pub trait CubeStrategy<TREE> {
         rng: &mut R,
         n_units: NonZeroUsize,
     ) where
-        R: RandomNumberGenerator;
+        R: FloatRng;
     // Used for stratified
     fn reset_to_ids(
         &mut self,
@@ -97,7 +101,7 @@ where
     #[inline]
     pub fn sample<R>(&mut self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         self.run(rng);
         self.controller.sample_vec()
@@ -106,7 +110,7 @@ where
     #[inline]
     pub fn run<R>(&mut self, rng: &mut R)
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         self.run_flight(rng);
         self.run_landing(rng);
@@ -119,7 +123,7 @@ where
     #[inline]
     pub fn run_flight<R>(&mut self, rng: &mut R)
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         let b_cols = self.adjusted_data.ncol();
         assert_eq!(
@@ -147,7 +151,7 @@ where
     #[inline]
     pub fn run_landing<R>(&mut self, rng: &mut R)
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         let b_cols = self.adjusted_data.ncol();
         let len = self.controller.indices().len();
@@ -235,7 +239,7 @@ where
     #[inline]
     fn update_probabilities<R>(&mut self, rng: &mut R)
     where
-        R: RandomNumberGenerator,
+        R: Rand<f64>,
     {
         let uvec = find_vector_in_null_space(&mut self.candidate_data);
         let mut lambdas = (f64::MAX, f64::MAX);
@@ -257,8 +261,7 @@ where
             }
         }
 
-        let lambda = if rng
-            .one_of_f64(lambdas.0, lambdas.1)
+        let lambda = if random_weighted(rng, lambdas.0, lambdas.1)
             .expect("both lambdas to be non-negative, with at least one positive")
         {
             lambdas.0
@@ -298,7 +301,7 @@ impl CubeStrategy<()> for SequentialCubeStrategy {
         _rng: &mut R,
         n_units: NonZeroUsize,
     ) where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         set_candidates_from_indices_sequentially(candidates, controller.indices(), n_units);
     }
@@ -345,7 +348,7 @@ impl CubeStrategy<()> for RandomCubeStrategy {
         rng: &mut R,
         n_units: NonZeroUsize,
     ) where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         set_candidates_from_indices_randomly(rng, candidates, controller.indices(), n_units);
     }
@@ -422,7 +425,7 @@ where
         rng: &mut R,
         n_units: NonZeroUsize,
     ) where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         assert!(
             n_units.get() > 1,
@@ -523,7 +526,7 @@ pub trait CubeSampling {
     /// # use envisim_samplr::*;
     /// # use envisim_utils::random::*;
     /// # use envisim_utils::matrix::*;
-    /// let mut rng = SmallRng::try_sys_rng().unwrap();
+    /// let mut rng = try_sys_rng().unwrap();
     /// let p: Vec<f64> = vec![0.2, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9];
     /// let m = Matrix::new(vec![
     ///     0.2, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9,
@@ -538,7 +541,7 @@ pub trait CubeSampling {
     #[must_use]
     fn cube<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator;
+        R: FloatRng;
     /// Draw a sample using the cube method.
     /// The sample is balanced on the provided auxilliary variables in `balancing`.
     /// For fixed sized samples, the first auxilliary variable should be the probability vector.
@@ -550,7 +553,7 @@ pub trait CubeSampling {
     /// # use envisim_samplr::*;
     /// # use envisim_utils::random::*;
     /// # use envisim_utils::matrix::Matrix;
-    /// let mut rng = SmallRng::try_sys_rng().unwrap();
+    /// let mut rng = try_sys_rng().unwrap();
     /// let p: Vec<f64> = vec![0.2, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9];
     /// let m = Matrix::new(vec![
     ///     0.2, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9,
@@ -565,7 +568,7 @@ pub trait CubeSampling {
     #[must_use]
     fn sequential_cube<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator;
+        R: FloatRng;
 }
 pub trait LocalCubeSampling<P>
 where
@@ -574,7 +577,7 @@ where
     #[must_use]
     fn local_cube<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator;
+        R: FloatRng;
 }
 impl<PS, AUX, T> CubeSampling for SamplingOptions<PS, AUX, BalancingOptions<MatrixBase<T>>>
 where
@@ -584,14 +587,14 @@ where
     #[inline]
     fn cube<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         RandomCubeStrategy::new(self).sample(rng)
     }
     #[inline]
     fn sequential_cube<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         SequentialCubeStrategy::new(self).sample(rng)
     }
@@ -606,7 +609,7 @@ where
     #[inline]
     fn local_cube<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         LocalCubeStrategy::new(self).sample(rng)
     }

--- a/envisim_samplr/src/cube_method/stratified.rs
+++ b/envisim_samplr/src/cube_method/stratified.rs
@@ -26,7 +26,10 @@ use envisim_utils::matrix::{
     RawData,
 };
 use envisim_utils::probabilities::FloatProbabilities;
-use envisim_utils::random::RandomNumberGenerator;
+use envisim_utils::random::{
+    FloatRng,
+    Rand,
+};
 use envisim_utils::sample_controller::{
     SampleController,
     UnitRemoving,
@@ -81,7 +84,7 @@ where
     ) -> SamplingResult<Self>
     where
         PS: ProbabilitySpec,
-        R: RandomNumberGenerator,
+        R: Rand<usize>,
         T: RawData<Elem = f64>,
     {
         let org_probabilities = options.probabilities().as_f64_slice();
@@ -118,7 +121,7 @@ where
         )]
         let strata = HashMap::<STRATA, Vec<usize>, FxSeededState>::with_capacity_and_hasher(
             org_probabilities.len() / 10,
-            FxSeededState::with_seed(rng.rusize()),
+            FxSeededState::with_seed(rng.rand()),
         );
 
         let this = Self {
@@ -168,7 +171,7 @@ where
     #[inline]
     fn sample<R>(&mut self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         self.flight_per_stratum(rng);
         if self.strata.is_empty() {
@@ -185,7 +188,7 @@ where
     #[inline]
     fn flight_per_stratum<R>(&mut self, rng: &mut R)
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         let mut removable_stratums = Vec::<STRATA>::new();
         for (stratum_key, stratum) in &mut self.strata {
@@ -214,7 +217,7 @@ where
     #[inline]
     fn flight_on_full<R>(&mut self, rng: &mut R)
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         let adj_data_dim = MatrixDims::new(
             self.balancing_data.nrow(),
@@ -271,7 +274,7 @@ where
     #[inline]
     fn landing_per_stratum<R>(&mut self, rng: &mut R)
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         let probabilities = self.org_probabilities.as_ref();
 
@@ -324,7 +327,7 @@ where
 /// # use envisim_samplr::cube_method::*;
 /// # use envisim_utils::random::*;
 /// # use envisim_utils::matrix::*;
-/// let mut rng = SmallRng::try_sys_rng().unwrap();
+/// let mut rng = try_sys_rng().unwrap();
 /// let bal_m = Matrix::new(vec![
 ///     0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2,
 ///     0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9,
@@ -345,7 +348,7 @@ pub fn cube_stratified<R, PS, AUX, T, STRATA>(
     strata: &[STRATA],
 ) -> SamplingResult<Vec<usize>>
 where
-    R: RandomNumberGenerator,
+    R: FloatRng,
     PS: ProbabilitySpec,
     T: RawData<Elem = f64>,
     STRATA: Copy + Eq + Hash,
@@ -368,7 +371,7 @@ where
 /// # use envisim_samplr::cube_method::*;
 /// # use envisim_utils::random::*;
 /// # use envisim_utils::matrix::*;
-/// let mut rng = SmallRng::try_sys_rng().unwrap();
+/// let mut rng = try_sys_rng().unwrap();
 /// let bal_m = Matrix::new(vec![
 ///     0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2,
 ///     0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9,
@@ -394,7 +397,7 @@ pub fn local_cube_stratified<R, PS, P, T, STRATA>(
     strata: &[STRATA],
 ) -> SamplingResult<Vec<usize>>
 where
-    R: RandomNumberGenerator,
+    R: FloatRng,
     PS: ProbabilitySpec,
     P: PointSet,
     T: RawData<Elem = f64>,

--- a/envisim_samplr/src/cube_method/utils.rs
+++ b/envisim_samplr/src/cube_method/utils.rs
@@ -19,7 +19,7 @@ use envisim_utils::matrix::{
     Dimensions,
     Matrix,
 };
-use envisim_utils::random::RandomNumberGenerator;
+use envisim_utils::random::FloatRng;
 use envisim_utils::sampling_options::SamplingOptions;
 
 /// Set candidates by drawing randomly from the indices list, i.e. a basic fallback
@@ -30,7 +30,7 @@ pub fn set_candidates_from_indices_randomly<R>(
     indices: &Indices,
     len: NonZeroUsize,
 ) where
-    R: RandomNumberGenerator,
+    R: FloatRng,
 {
     use crate::EqualProbabilitySampling;
     candidates.clear();

--- a/envisim_samplr/src/dbd/annealing.rs
+++ b/envisim_samplr/src/dbd/annealing.rs
@@ -14,7 +14,11 @@
 
 use std::num::NonZeroUsize;
 
-use envisim_utils::random::RandomNumberGenerator;
+use envisim_utils::random::{
+    FloatRng,
+    Rand,
+    Rng,
+};
 
 /// Contains the annealing temperature tracker
 #[must_use]
@@ -63,12 +67,12 @@ impl AnnealingTemperature {
     #[inline]
     fn accept_change<R>(&self, rng: &mut R, change: f64) -> bool
     where
-        R: RandomNumberGenerator,
+        R: Rand<f64>,
     {
         if !self.is_positive() {
             return false;
         }
-        let u = rng.rf64();
+        let u: f64 = rng.rand();
         let v = (-change / self.temperature).exp();
         u < v
     }
@@ -94,7 +98,7 @@ pub trait AnnealingDistributionalDesign {
     /// Draws the random units
     fn draw_units<R>(&mut self, rng: &mut R)
     where
-        R: RandomNumberGenerator;
+        R: Rng;
     /// Evaluate the effect of a switch
     #[must_use]
     fn evaluate_switch(&mut self) -> Option<f64>;
@@ -106,7 +110,7 @@ pub trait AnnealingDistributionalDesign {
     #[inline]
     fn run<R>(&mut self, rng: &mut R, iterations: NonZeroUsize)
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         for _ in 0..iterations.get() {
             self.draw_units(rng);

--- a/envisim_samplr/src/dbd/dbd_circular.rs
+++ b/envisim_samplr/src/dbd/dbd_circular.rs
@@ -15,7 +15,7 @@
 use std::num::NonZeroUsize;
 
 pub use config::*;
-use envisim_utils::random::RandomNumberGenerator;
+use envisim_utils::random::Rand;
 use envisim_utils::spatial::PointSet;
 use num_traits::ToPrimitive;
 
@@ -225,11 +225,11 @@ where
     #[inline]
     fn draw_units<R>(&mut self, rng: &mut R)
     where
-        R: RandomNumberGenerator,
+        R: Rand<usize>,
     {
         let n = self.tcp().population_size().get();
-        let a = rng.rusize_to(n);
-        let b = rng.rusize_to(n - 1);
+        let a = rng.rand_in(0..n);
+        let b = rng.rand_in(0..(n - 1));
         self.pair = if a == b { (a, n - 1) } else { (a, b) };
     }
     #[inline]

--- a/envisim_samplr/src/dbd/dbd_tc.rs
+++ b/envisim_samplr/src/dbd/dbd_tc.rs
@@ -15,7 +15,10 @@
 use std::num::NonZeroUsize;
 
 pub use config::*;
-use envisim_utils::random::RandomNumberGenerator;
+use envisim_utils::random::{
+    FloatRng,
+    Rand,
+};
 use envisim_utils::sampling_options::SamplingOptions;
 use envisim_utils::spatial::PointSet;
 use num_traits::ToPrimitive;
@@ -213,7 +216,7 @@ impl<P> DbdTacticalConfiguration<P> {
     ) -> Result<Self, TacticalConfiguration>
     where
         P: PointSet<N = f64>,
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         let population_size = matrix.size();
         let sample_size = sample_size.min(population_size);
@@ -313,21 +316,19 @@ where
     fn temperature_mut(&mut self) -> &mut AnnealingTemperature { &mut self.temperature }
 
     #[inline]
-    fn draw_units<R: RandomNumberGenerator>(&mut self, rng: &mut R) {
+    fn draw_units<R>(&mut self, rng: &mut R)
+    where
+        R: Rand<usize>,
+    {
         let sample_size = self.tcp().sample_size().get();
+        let n_samples = self.tcp().n_samples().get();
 
         loop {
-            let a_unit = (
-                rng.rusize_to(self.tcp().n_samples().get()),
-                rng.rusize_to(sample_size),
-            );
-            let mut b_unit = (
-                rng.rusize_to(self.tcp().n_samples().get() - 1),
-                rng.rusize_to(sample_size),
-            );
+            let a_unit = (rng.rand_in(0..n_samples), rng.rand_in(0..sample_size));
+            let mut b_unit = (rng.rand_in(0..(n_samples - 1)), rng.rand_in(0..sample_size));
 
             if a_unit.0 == b_unit.0 {
-                b_unit.0 = self.tcp().n_samples().get() - 1;
+                b_unit.0 = n_samples - 1;
             }
 
             let a_id = self.configuration.bucket_get(a_unit.0, a_unit.1);

--- a/envisim_samplr/src/dbd/mod.rs
+++ b/envisim_samplr/src/dbd/mod.rs
@@ -51,7 +51,7 @@ mod dbd_trait {
     //! Distributionally balanced design trait
     use std::num::NonZeroUsize;
 
-    use envisim_utils::random::RandomNumberGenerator;
+    use envisim_utils::random::FloatRng;
     use envisim_utils::sampling_options::{
         ProbabilitySpecEqual,
         SamplingOptions,
@@ -84,7 +84,7 @@ mod dbd_trait {
         /// # use envisim_samplr::*;
         /// # use envisim_utils::random::*;
         /// # use envisim_utils::matrix::*;
-        /// let mut rng = SmallRng::try_sys_rng().unwrap();
+        /// let mut rng = try_sys_rng().unwrap();
         /// let m = Matrix::new(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 10).unwrap();
         /// let opts = SamplingOptions::new_equal(10, 2)?.set_spreading(m)?;
         /// let dbd_opts = DistributionalDesignOptions::default();
@@ -102,7 +102,7 @@ mod dbd_trait {
             dbs_options: DistributionalDesignOptions,
         ) -> SamplingResult<CircularConfiguration>
         where
-            R: RandomNumberGenerator;
+            R: FloatRng;
         /// Construct a distributionally balanced design using a tactical configuration
         ///
         /// # Examples
@@ -110,7 +110,7 @@ mod dbd_trait {
         /// # use envisim_samplr::*;
         /// # use envisim_utils::random::*;
         /// # use envisim_utils::matrix::*;
-        /// let mut rng = SmallRng::try_sys_rng().unwrap();
+        /// let mut rng = try_sys_rng().unwrap();
         /// let m = Matrix::new(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 10).unwrap();
         /// let opts = SamplingOptions::new_equal(10, 2)?.set_spreading(m)?;
         /// let dbd_opts = DistributionalDesignOptions::default();
@@ -128,7 +128,7 @@ mod dbd_trait {
             dbs_options: DistributionalDesignOptions,
         ) -> SamplingResult<TacticalConfiguration>
         where
-            R: RandomNumberGenerator;
+            R: FloatRng;
         /// # Errors
         /// Returns an error if `sample_size` is 0.
         fn dbd_circular_iterations<R>(
@@ -139,7 +139,7 @@ mod dbd_trait {
             by: NonZeroUsize,
         ) -> SamplingResult<Vec<f64>>
         where
-            R: RandomNumberGenerator;
+            R: FloatRng;
         /// # Errors
         /// Returns an error if `sample_size` is 0.
         fn dbd_tc_iterations<R>(
@@ -150,7 +150,7 @@ mod dbd_trait {
             by: NonZeroUsize,
         ) -> SamplingResult<Vec<f64>>
         where
-            R: RandomNumberGenerator;
+            R: FloatRng;
     }
 
     impl<P, BAL> DistributionalDesigns
@@ -165,7 +165,7 @@ mod dbd_trait {
             dbs_options: DistributionalDesignOptions,
         ) -> SamplingResult<CircularConfiguration>
         where
-            R: RandomNumberGenerator,
+            R: FloatRng,
         {
             let sample_size =
                 NonZeroUsize::new(self.sample_size()).ok_or(SamplingError::ZeroSampleSize)?;
@@ -188,7 +188,7 @@ mod dbd_trait {
             dbs_options: DistributionalDesignOptions,
         ) -> SamplingResult<TacticalConfiguration>
         where
-            R: RandomNumberGenerator,
+            R: FloatRng,
         {
             let sample_size =
                 NonZeroUsize::new(self.sample_size()).ok_or(SamplingError::ZeroSampleSize)?;
@@ -223,7 +223,7 @@ mod dbd_trait {
             by: NonZeroUsize,
         ) -> SamplingResult<Vec<f64>>
         where
-            R: RandomNumberGenerator,
+            R: FloatRng,
         {
             if to < by {
                 return Err(SamplingError::MaxIterations(to));
@@ -285,7 +285,7 @@ mod dbd_trait {
             by: NonZeroUsize,
         ) -> SamplingResult<Vec<f64>>
         where
-            R: RandomNumberGenerator,
+            R: FloatRng,
         {
             if to < by {
                 return Err(SamplingError::MaxIterations(to));
@@ -350,7 +350,7 @@ mod dbd_trait {
             by: NonZeroUsize,
         ) -> SamplingResult<Vec<f64>>
         where
-            R: RandomNumberGenerator;
+            R: FloatRng;
         /// Runs the tactical configuration dbd until `to`, reporting the energy in `by` intervals.
         ///
         /// # Errors
@@ -363,7 +363,7 @@ mod dbd_trait {
             by: NonZeroUsize,
         ) -> SamplingResult<Vec<f64>>
         where
-            R: RandomNumberGenerator;
+            R: FloatRng;
     }
     impl<P, BAL> DistributionalDesignEvaluators
         for SamplingOptions<ProbabilitySpecEqual, SpreadingOptions<P>, BAL>
@@ -379,7 +379,7 @@ mod dbd_trait {
             by: NonZeroUsize,
         ) -> SamplingResult<Vec<f64>>
         where
-            R: RandomNumberGenerator,
+            R: FloatRng,
         {
             if to < by {
                 return Err(SamplingError::MaxIterations(to));
@@ -437,7 +437,7 @@ mod dbd_trait {
             by: NonZeroUsize,
         ) -> SamplingResult<Vec<f64>>
         where
-            R: RandomNumberGenerator,
+            R: FloatRng,
         {
             if to < by {
                 return Err(SamplingError::MaxIterations(to));

--- a/envisim_samplr/src/dbd/tc_parameters.rs
+++ b/envisim_samplr/src/dbd/tc_parameters.rs
@@ -14,7 +14,7 @@
 
 use std::num::NonZeroUsize;
 
-use envisim_utils::random::RandomNumberGenerator;
+use envisim_utils::random::Rand;
 use envisim_utils::spatial::PointSet;
 use num_traits::ToPrimitive;
 
@@ -140,10 +140,10 @@ pub trait DbdConfiguration {
     #[inline]
     fn draw<R>(&self, rng: &mut R) -> impl Iterator<Item = usize> + Clone + '_
     where
-        R: RandomNumberGenerator,
+        R: Rand<usize>,
     {
         let n_samples = self.tcp().n_samples().get();
-        let sample_id = rng.rusize_to(n_samples);
+        let sample_id = rng.rand_in(0..n_samples);
         self.sample(sample_id)
     }
     /// Returns the energy of a specific sample multiplied by the sample size

--- a/envisim_samplr/src/equal.rs
+++ b/envisim_samplr/src/equal.rs
@@ -14,9 +14,11 @@
 //!
 //! Implements [`EqualProbabilitySampling`] for [`SamplingOptions`].
 
-use std::iter::repeat_with;
-
-use envisim_utils::random::RandomNumberGenerator;
+use envisim_utils::random::{
+    FloatRng,
+    Rand,
+    RandSlice,
+};
 use envisim_utils::sampling_options::ProbabilitySpecEqual;
 pub use envisim_utils::sampling_options::SamplingOptions;
 
@@ -29,48 +31,48 @@ pub trait EqualProbabilitySampling {
     /// ```
     /// # use envisim_samplr::*;
     /// # use envisim_utils::random::*;
-    /// let mut rng = SmallRng::try_sys_rng().unwrap();
+    /// let mut rng = try_sys_rng().unwrap();
     /// let s = SamplingOptions::new_equal(10, 5)?.srs(&mut rng);
     /// assert_eq!(s.len(), 5);
     /// # Ok::<(), SamplingOptionsError>(())
     /// ```
     fn srs<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator;
+        R: FloatRng;
     /// Draw a simple random sample with replacement
     ///
     /// # Examples
     /// ```
     /// # use envisim_samplr::*;
     /// # use envisim_utils::random::*;
-    /// let mut rng = SmallRng::try_sys_rng().unwrap();
+    /// let mut rng = try_sys_rng().unwrap();
     /// let s = SamplingOptions::new_equal(10, 5)?.srs_with_replacement(&mut rng);
     /// assert_eq!(s.len(), 5);
     /// # Ok::<(), SamplingOptionsError>(())
     /// ```
     fn srs_with_replacement<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator;
+        R: FloatRng;
     /// Draw a sample using Bernoulli sampling
     ///
     /// # Examples
     /// ```
     /// # use envisim_samplr::*;
     /// # use envisim_utils::random::*;
-    /// let mut rng = SmallRng::try_sys_rng().unwrap();
+    /// let mut rng = try_sys_rng().unwrap();
     /// let s = SamplingOptions::new_equal(10, 5)?.bernoulli(&mut rng);
     /// # Ok::<(), SamplingOptionsError>(())
     /// ```
     fn bernoulli<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator;
+        R: FloatRng;
 }
 impl<AUX, BAL> EqualProbabilitySampling for SamplingOptions<ProbabilitySpecEqual, AUX, BAL> {
     #[must_use]
     #[inline]
     fn srs<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator,
+        R: Rand<usize>,
     {
         let population_size = self.population_size();
         let sample_size = self.sample_size();
@@ -84,7 +86,7 @@ impl<AUX, BAL> EqualProbabilitySampling for SamplingOptions<ProbabilitySpecEqual
         let mut sample = Vec::<usize>::with_capacity(sample_size);
 
         for i in 0..population_size.get() {
-            if rng.rusize_to(population_size.get() - i) < sample_size - sample.len() {
+            if rng.rand_in(0..(population_size.get() - i)) < sample_size - sample.len() {
                 sample.push(i);
             }
         }
@@ -95,7 +97,7 @@ impl<AUX, BAL> EqualProbabilitySampling for SamplingOptions<ProbabilitySpecEqual
     #[inline]
     fn srs_with_replacement<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator,
+        R: RandSlice<usize>,
     {
         let population_size = self.population_size();
         let sample_size = self.sample_size();
@@ -106,10 +108,8 @@ impl<AUX, BAL> EqualProbabilitySampling for SamplingOptions<ProbabilitySpecEqual
             return (0..population_size.get()).collect();
         }
 
-        let mut sample: Vec<usize> = repeat_with(|| rng.rusize_to(population_size.get()))
-            .take(sample_size)
-            .collect();
-
+        let mut sample = vec![0; sample_size];
+        rng.rand_to_n(&mut sample, population_size.get());
         sample.sort_unstable();
         sample
     }
@@ -117,19 +117,17 @@ impl<AUX, BAL> EqualProbabilitySampling for SamplingOptions<ProbabilitySpecEqual
     #[inline]
     fn bernoulli<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator,
+        R: RandSlice<usize>,
     {
         let population_size = self.population_size().get();
         let sample_size = self.sample_size();
 
-        let mut sample = Vec::with_capacity(population_size);
-
-        for i in 0..population_size {
-            if rng.rusize_to(population_size) < sample_size {
-                sample.push(i);
-            }
-        }
-
-        sample
+        let mut rands = vec![0; population_size];
+        rng.rand_in_n(&mut rands, 0..population_size);
+        rands
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &v)| (v < sample_size).then_some(i))
+            .collect()
     }
 }

--- a/envisim_samplr/src/pivotal_method/base.rs
+++ b/envisim_samplr/src/pivotal_method/base.rs
@@ -14,7 +14,10 @@
 
 use envisim_utils::indices::Pair;
 use envisim_utils::probabilities::ProbabilityStore;
-use envisim_utils::random::RandomNumberGenerator;
+use envisim_utils::random::{
+    FloatRng,
+    Rand,
+};
 use envisim_utils::sample_controller::SampleController;
 use envisim_utils::sampling_options::{
     ProbabilitySpec,
@@ -51,7 +54,7 @@ where
     #[inline]
     fn select_pair<R>(&mut self, controller: &mut SampleController<PST, ()>, _rng: &mut R) -> Pair
     where
-        R: RandomNumberGenerator,
+        R: Rand<usize>,
     {
         // If Indices is initialized in reverse order, last units should be able to swap out safely,
         // so pairs are always in correct order
@@ -83,7 +86,7 @@ where
     #[inline]
     fn select_pair<R>(&mut self, controller: &mut SampleController<PST, ()>, rng: &mut R) -> Pair
     where
-        R: RandomNumberGenerator,
+        R: Rand<usize>,
     {
         let pair: Pair = controller.indices().into();
         if !pair.is_more() {
@@ -95,7 +98,7 @@ where
             .indices()
             .draw(rng)
             .expect("indices to contain units");
-        let k = rng.rusize_to(len - 1);
+        let k = rng.rand_to(len - 1);
         let mut id2 = controller.indices()[k];
 
         if id1 == id2 {
@@ -117,7 +120,7 @@ pub trait PivotalSampling {
     /// ```
     /// # use envisim_samplr::*;
     /// # use envisim_utils::random::*;
-    /// let mut rng = SmallRng::try_sys_rng().unwrap();
+    /// let mut rng = try_sys_rng().unwrap();
     /// let p: Vec<f64> = vec![0.2f64, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9];
     /// let opts = SamplingOptions::new(p.into())?;
     /// let s = opts.spm(&mut rng);
@@ -126,7 +129,7 @@ pub trait PivotalSampling {
     /// ```
     fn spm<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator;
+        R: FloatRng;
     /// Draw a sample using the random pivotal method.
     /// A variant of the pivotal method where unit competes in a random order.
     ///
@@ -134,7 +137,7 @@ pub trait PivotalSampling {
     /// ```
     /// # use envisim_samplr::*;
     /// # use envisim_utils::random::*;
-    /// let mut rng = SmallRng::try_sys_rng().unwrap();
+    /// let mut rng = try_sys_rng().unwrap();
     /// let p: Vec<f64> = vec![0.2f64, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9];
     /// let opts = SamplingOptions::new(p.into())?;
     /// let s = opts.rpm(&mut rng);
@@ -143,7 +146,7 @@ pub trait PivotalSampling {
     /// ```
     fn rpm<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator;
+        R: FloatRng;
 }
 
 impl<PS, AUX, BAL> PivotalSampling for SamplingOptions<PS, AUX, BAL>
@@ -153,14 +156,14 @@ where
     #[inline]
     fn spm<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         SequentialStrategy::new(self).sample(rng)
     }
     #[inline]
     fn rpm<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         RandomStrategy::new(self).sample(rng)
     }

--- a/envisim_samplr/src/pivotal_method/runner.rs
+++ b/envisim_samplr/src/pivotal_method/runner.rs
@@ -14,7 +14,10 @@
 
 use envisim_utils::indices::Pair;
 use envisim_utils::probabilities::ProbabilityStore;
-use envisim_utils::random::RandomNumberGenerator;
+use envisim_utils::random::{
+    FloatRng,
+    Rand,
+};
 use envisim_utils::sample_controller::{
     SampleController,
     UnitRemoving,
@@ -23,7 +26,7 @@ use envisim_utils::sample_controller::{
 pub trait PivotalStrategy<PST, TREE> {
     fn select_pair<R>(&mut self, controller: &mut SampleController<PST, TREE>, rng: &mut R) -> Pair
     where
-        R: RandomNumberGenerator;
+        R: Rand<usize>;
 }
 
 #[expect(
@@ -48,7 +51,7 @@ where
     #[inline]
     pub fn sample<R>(&mut self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         self.run(rng);
         self.controller.sample_vec()
@@ -57,7 +60,7 @@ where
     #[inline]
     pub fn run<R>(&mut self, rng: &mut R)
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         while self.update_probabilities(rng) {}
         let _last = self.controller.unit_decide_last(rng);
@@ -67,7 +70,7 @@ where
     #[inline]
     fn update_probabilities<R>(&mut self, rng: &mut R) -> bool
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         let (id1, id2, cont) = match self.strategy.select_pair(&mut self.controller, rng) {
             Pair::More(id1, id2) => (id1, id2, true),

--- a/envisim_samplr/src/pivotal_method/spatial.rs
+++ b/envisim_samplr/src/pivotal_method/spatial.rs
@@ -22,7 +22,11 @@ use envisim_utils::kd_tree::{
     Tree,
 };
 use envisim_utils::probabilities::ProbabilityStore;
-use envisim_utils::random::RandomNumberGenerator;
+use envisim_utils::random::{
+    FloatRng,
+    Rand,
+    random_element,
+};
 use envisim_utils::sample_controller::SampleController;
 use envisim_utils::sampling_options::{
     ProbabilitySpec,
@@ -108,7 +112,7 @@ where
         rng: &mut R,
     ) -> Pair
     where
-        R: RandomNumberGenerator,
+        R: Rand<usize>,
     {
         let pair: Pair = controller.indices().into();
         if !pair.is_more() {
@@ -148,9 +152,8 @@ where
             }
 
             if !self.candidates.is_empty() {
-                let id2 = *rng
-                    .relement(&self.candidates)
-                    .expect("candidates to have elements");
+                let id2 =
+                    *random_element(rng, &self.candidates).expect("candidates to have elements");
                 return Pair::More(id1, id2);
             }
         }
@@ -208,7 +211,7 @@ where
         rng: &mut R,
     ) -> Pair
     where
-        R: RandomNumberGenerator,
+        R: Rand<usize>,
     {
         let pair: Pair = controller.indices().into();
         if !pair.is_more() {
@@ -266,7 +269,7 @@ where
 
             // Some mutual nn has been found
             if left > 0 {
-                let id2 = *rng.relement(&self.candidates[0..left]).expect("left > 0");
+                let id2 = *random_element(rng, &self.candidates[0..left]).expect("left > 0");
                 return Pair::More(id1, id2);
             }
             // If no mutual nn has been found, we select one of the candidates by random to be the
@@ -277,8 +280,7 @@ where
             }
 
             self.history.push(
-                *rng.relement(&self.candidates)
-                    .expect("candidates to have positive length"),
+                *random_element(rng, &self.candidates).expect("candidates to have positive length"),
             );
         }
     }
@@ -325,7 +327,7 @@ where
         rng: &mut R,
     ) -> Pair
     where
-        R: RandomNumberGenerator,
+        R: Rand<usize>,
     {
         let pair: Pair = controller.indices().into();
         if !pair.is_more() {
@@ -341,8 +343,7 @@ where
             .expect("id1 to exist")
             .search(controller.tree())
             .expect("nn to be found");
-        let id2 = rng
-            .relement(self.searcher.neighbours())
+        let id2 = random_element(rng, self.searcher.neighbours())
             .expect("neighbours to have positive length")
             .id();
 
@@ -362,7 +363,7 @@ where
     /// # use envisim_samplr::*;
     /// # use envisim_utils::random::*;
     /// # use envisim_utils::matrix::Matrix;
-    /// let mut rng = SmallRng::try_sys_rng().unwrap();
+    /// let mut rng = try_sys_rng().unwrap();
     /// let p: Vec<f64> = vec![0.2, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9];
     /// let m = Matrix::new(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 10).unwrap();
     /// let s = SamplingOptions::new(p.into())?
@@ -373,7 +374,7 @@ where
     /// ```
     fn lpm_1<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator;
+        R: FloatRng;
     /// Draw a sample using the local pivotal method 1.
     /// The sample is spatially balanced on the provided auxilliary variables in `data`.
     ///
@@ -382,7 +383,7 @@ where
     /// # use envisim_samplr::*;
     /// # use envisim_utils::random::*;
     /// # use envisim_utils::matrix::Matrix;
-    /// let mut rng = SmallRng::try_sys_rng().unwrap();
+    /// let mut rng = try_sys_rng().unwrap();
     /// let p: Vec<f64> = vec![0.2, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9];
     /// let m = Matrix::new(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 10).unwrap();
     /// let s = SamplingOptions::new(p.into())?
@@ -393,7 +394,7 @@ where
     /// ```
     fn lpm_1s<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator;
+        R: FloatRng;
     /// Draw a sample using the local pivotal method 2.
     /// The sample is spatially balanced on the provided auxilliary variables in `data`.
     ///
@@ -402,7 +403,7 @@ where
     /// # use envisim_samplr::*;
     /// # use envisim_utils::random::*;
     /// # use envisim_utils::matrix::Matrix;
-    /// let mut rng = SmallRng::try_sys_rng().unwrap();
+    /// let mut rng = try_sys_rng().unwrap();
     /// let p: Vec<f64> = vec![0.2, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9];
     /// let m = Matrix::new(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 10).unwrap();
     /// let s = SamplingOptions::new(p.into())?
@@ -413,7 +414,7 @@ where
     /// ```
     fn lpm_2<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator;
+        R: FloatRng;
 }
 impl<PS, P, BAL> LocalPivotalSampling<P> for SamplingOptions<PS, SpreadingOptions<P>, BAL>
 where
@@ -423,21 +424,21 @@ where
     #[inline]
     fn lpm_1<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         LocalStrategy1::new(self).sample(rng)
     }
     #[inline]
     fn lpm_1s<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         LocalStrategy1S::new(self).sample(rng)
     }
     #[inline]
     fn lpm_2<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         LocalStrategy2::new(self).sample(rng)
     }
@@ -455,7 +456,7 @@ where
 /// # use envisim_samplr::pivotal_method::hierarchical_lpm_2;
 /// # use envisim_utils::random::*;
 /// # use envisim_utils::matrix::Matrix;
-/// let mut rng = SmallRng::try_sys_rng().unwrap();
+/// let mut rng = try_sys_rng().unwrap();
 /// let p: Vec<f64> = vec![0.2, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9];
 /// let m = Matrix::new(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 10).unwrap();
 /// let options = SamplingOptions::new(p.into())?.set_spreading(m)?;
@@ -488,7 +489,7 @@ pub fn hierarchical_lpm_2<R, PS, P, BAL>(
     sizes: &[usize],
 ) -> SamplingResult<Vec<Vec<usize>>>
 where
-    R: RandomNumberGenerator,
+    R: FloatRng,
     PS: ProbabilitySpec,
     P: PointSet,
 {

--- a/envisim_samplr/src/systematic.rs
+++ b/envisim_samplr/src/systematic.rs
@@ -14,7 +14,10 @@
 //!
 //! Implements [`SystematicSampling`] for [`SamplingOptions`].
 
-use envisim_utils::random::RandomNumberGenerator;
+use envisim_utils::random::{
+    FloatRng,
+    Rand,
+};
 pub use envisim_utils::sampling_options::SamplingOptions;
 use envisim_utils::sampling_options::{
     ProbabilitySpec,
@@ -30,10 +33,10 @@ use crate::utils::shuffled_indices;
 #[inline]
 fn from_order_equal<R>(rng: &mut R, spec: ProbabilitySpecEqual, order: &[usize]) -> Vec<usize>
 where
-    R: RandomNumberGenerator,
+    R: Rand<usize>,
 {
     let mut sample = Vec::<usize>::with_capacity(spec.sample_size() + 1);
-    let mut r = rng.rusize_to(spec.population_size().get());
+    let mut r = rng.rand_to(spec.population_size().get());
     let mut psum: usize = 0;
 
     for &id in order {
@@ -53,7 +56,7 @@ where
 #[inline]
 fn from_order<R>(rng: &mut R, probabilities: &[f64], order: &[usize]) -> Vec<usize>
 where
-    R: RandomNumberGenerator,
+    R: Rand<f64>,
 {
     let mut sample = Vec::<usize>::with_capacity(
         probabilities
@@ -63,7 +66,7 @@ where
             .to_usize()
             .expect("probability sum to be contained in usize"),
     );
-    let mut r = rng.rf64();
+    let mut r = rng.rand();
     let mut psum: f64 = 0.0;
 
     for &id in order {
@@ -86,7 +89,7 @@ pub trait SystematicSampling {
     /// ```
     /// # use envisim_samplr::*;
     /// # use envisim_utils::random::*;
-    /// let mut rng = SmallRng::try_sys_rng().unwrap();
+    /// let mut rng = try_sys_rng().unwrap();
     /// let p: Vec<f64> = vec![0.2, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9];
     /// let s = SamplingOptions::new(p.into())?.systematic(&mut rng);
     /// assert_eq!(s.len(), 5);
@@ -94,14 +97,14 @@ pub trait SystematicSampling {
     /// ```
     fn systematic<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator;
+        R: FloatRng;
     /// Draw a systematic sample, using a random order
     ///
     /// # Examples
     /// ```
     /// # use envisim_samplr::*;
     /// # use envisim_utils::random::*;
-    /// let mut rng = SmallRng::try_sys_rng().unwrap();
+    /// let mut rng = try_sys_rng().unwrap();
     /// let p: Vec<f64> = vec![0.2, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9];
     /// let s = SamplingOptions::new(p.into())?.systematic_random_order(&mut rng);
     /// assert_eq!(s.len(), 5);
@@ -109,7 +112,7 @@ pub trait SystematicSampling {
     /// ```
     fn systematic_random_order<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator;
+        R: FloatRng;
 }
 impl<PS, AUX, BAL> SystematicSampling for SamplingOptions<PS, AUX, BAL>
 where
@@ -118,7 +121,7 @@ where
     #[inline]
     fn systematic<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         let population_size = self.population_size();
         let order: Vec<usize> = (0..population_size.get()).collect();
@@ -132,7 +135,7 @@ where
     #[inline]
     fn systematic_random_order<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         let population_size = self.population_size();
         let order = shuffled_indices(rng, population_size);

--- a/envisim_samplr/src/unequal.rs
+++ b/envisim_samplr/src/unequal.rs
@@ -22,7 +22,10 @@
 use std::cmp::Ordering;
 
 use envisim_utils::indices::Indices;
-use envisim_utils::random::RandomNumberGenerator;
+use envisim_utils::random::{
+    FloatRng,
+    Rand,
+};
 use envisim_utils::sample_controller::Sample;
 pub use envisim_utils::sampling_options::SamplingOptions;
 use envisim_utils::sampling_options::{
@@ -42,10 +45,10 @@ use crate::utils::poisson_internal;
 #[inline]
 fn draw<R>(rng: &mut R, probabilities: &[f64]) -> usize
 where
-    R: RandomNumberGenerator,
+    R: Rand<f64>,
 {
     let population_size = probabilities.len();
-    let rv = rng.rf64();
+    let rv = rng.rand();
     let mut psum: f64 = 0.0;
 
     for (i, &p) in probabilities.iter().enumerate() {
@@ -67,7 +70,7 @@ pub trait UnequalProbabilitySampling {
     /// ```
     /// # use envisim_samplr::*;
     /// # use envisim_utils::random::*;
-    /// let mut rng = SmallRng::try_sys_rng().unwrap();
+    /// let mut rng = try_sys_rng().unwrap();
     /// let p: Vec<f64> = vec![0.1; 10];
     /// let s = SamplingOptions::new(p.into())?.with_replacement(&mut rng, 5)?;
     /// assert_eq!(s.len(), 5);
@@ -78,7 +81,7 @@ pub trait UnequalProbabilitySampling {
     /// Returns an error if probabilities does not sum to 1.0.
     fn with_replacement<R>(&self, rng: &mut R, n: usize) -> SamplingResult<Vec<usize>>
     where
-        R: RandomNumberGenerator;
+        R: FloatRng;
     /// Draw a sample using a sampford design.
     /// Probabilities must sum to an integer.
     ///
@@ -86,7 +89,7 @@ pub trait UnequalProbabilitySampling {
     /// ```
     /// # use envisim_samplr::*;
     /// # use envisim_utils::random::*;
-    /// let mut rng = SmallRng::try_sys_rng().unwrap();
+    /// let mut rng = try_sys_rng().unwrap();
     /// let p: Vec<f64> = vec![0.2, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9];
     /// let s = SamplingOptions::new(p.into())?.sampford(&mut rng)?;
     /// assert_eq!(s.len(), 5);
@@ -97,7 +100,7 @@ pub trait UnequalProbabilitySampling {
     /// Returns an error if probabilities does not sum to an integer.
     fn sampford<R>(&self, rng: &mut R) -> SamplingResult<Vec<usize>>
     where
-        R: RandomNumberGenerator;
+        R: FloatRng;
     /// Draw a sample using a pareto design.
     /// Probabilities must sum to an integer.
     ///
@@ -105,7 +108,7 @@ pub trait UnequalProbabilitySampling {
     /// ```
     /// # use envisim_samplr::*;
     /// # use envisim_utils::random::*;
-    /// let mut rng = SmallRng::try_sys_rng().unwrap();
+    /// let mut rng = try_sys_rng().unwrap();
     /// let p: Vec<f64> = vec![0.2, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9];
     /// let s = SamplingOptions::new(p.into())?.pareto(&mut rng)?;
     /// assert_eq!(s.len(), 5);
@@ -116,7 +119,7 @@ pub trait UnequalProbabilitySampling {
     /// Returns an error if probabilities does not sum to an integer.
     fn pareto<R>(&self, rng: &mut R) -> SamplingResult<Vec<usize>>
     where
-        R: RandomNumberGenerator;
+        R: FloatRng;
     /// Draw a sample using a brewer design.
     /// Probabilities must sum to an integer.
     ///
@@ -124,7 +127,7 @@ pub trait UnequalProbabilitySampling {
     /// ```
     /// # use envisim_samplr::*;
     /// # use envisim_utils::random::*;
-    /// let mut rng = SmallRng::try_sys_rng().unwrap();
+    /// let mut rng = try_sys_rng().unwrap();
     /// let p: Vec<f64> = vec![0.2, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9];
     /// let s = SamplingOptions::new(p.into())?.brewer(&mut rng)?;
     /// assert_eq!(s.len(), 5);
@@ -135,14 +138,14 @@ pub trait UnequalProbabilitySampling {
     /// Returns an error if probabilities does not sum to an integer.
     fn brewer<R>(&self, rng: &mut R) -> SamplingResult<Vec<usize>>
     where
-        R: RandomNumberGenerator;
+        R: FloatRng;
     /// Draw a sample using a poisson design.
     ///
     /// # Examples
     /// ```
     /// # use envisim_samplr::*;
     /// # use envisim_utils::random::*;
-    /// let mut rng = SmallRng::try_sys_rng().unwrap();
+    /// let mut rng = try_sys_rng().unwrap();
     /// let p: Vec<f64> = vec![0.2, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9];
     /// let s = SamplingOptions::new(p.into())?.poisson(&mut rng);
     /// # Ok::<(), SamplingError>(())
@@ -150,7 +153,7 @@ pub trait UnequalProbabilitySampling {
     #[must_use]
     fn poisson<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator;
+        R: FloatRng;
     /// Draw a sample using a conditional poisson design.
     /// Redraws a poisson sample until the fixed sample size is achieved.
     /// May terminate after `max_iterations`.
@@ -159,7 +162,7 @@ pub trait UnequalProbabilitySampling {
     /// ```
     /// # use envisim_samplr::*;
     /// # use envisim_utils::random::*;
-    /// let mut rng = SmallRng::try_sys_rng().unwrap();
+    /// let mut rng = try_sys_rng().unwrap();
     /// let p: Vec<f64> = vec![0.2, 0.25, 0.35, 0.4, 0.5, 0.5, 0.55, 0.65, 0.7, 0.9];
     /// let s = SamplingOptions::new(p.into())?.conditional_poisson(&mut rng, 5)?;
     /// # Ok::<(), SamplingError>(())
@@ -169,7 +172,7 @@ pub trait UnequalProbabilitySampling {
     /// Returns an error if `sample_size` is larger than the population size.
     fn conditional_poisson<R>(&self, rng: &mut R, sample_size: usize) -> SamplingResult<Vec<usize>>
     where
-        R: RandomNumberGenerator;
+        R: FloatRng;
 }
 impl<AUX, BAL> UnequalProbabilitySampling
     for SamplingOptions<ProbabilitySpecUnequal<'_>, AUX, BAL>
@@ -177,7 +180,7 @@ impl<AUX, BAL> UnequalProbabilitySampling
     #[inline]
     fn with_replacement<R>(&self, rng: &mut R, n: usize) -> SamplingResult<Vec<usize>>
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         let probabilities = self.probabilities().as_f64_slice();
         if (self.probabilities().sample_size_f64() - 1.0).abs() > self.eps() {
@@ -191,7 +194,7 @@ impl<AUX, BAL> UnequalProbabilitySampling
         let mut rvs = Vec::<f64>::with_capacity(n);
 
         for _ in 0..n {
-            rvs.push(rng.rf64());
+            rvs.push(rng.rand());
         }
 
         rvs.sort_unstable_by(|a, b| a.partial_cmp(b).expect("rvs to not be NaN"));
@@ -230,7 +233,7 @@ impl<AUX, BAL> UnequalProbabilitySampling
     #[inline]
     fn sampford<R>(&self, rng: &mut R) -> SamplingResult<Vec<usize>>
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         let probabilities = self.probabilities().as_f64_slice();
         let eps = self.eps();
@@ -272,7 +275,7 @@ impl<AUX, BAL> UnequalProbabilitySampling
     #[inline]
     fn pareto<R>(&self, rng: &mut R) -> SamplingResult<Vec<usize>>
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         let probabilities = self.probabilities().as_f64_slice();
         let eps = self.eps();
@@ -287,7 +290,7 @@ impl<AUX, BAL> UnequalProbabilitySampling
         let q_values: Vec<f64> = probabilities
             .iter()
             .map(|&p| {
-                let u = rng.rf64();
+                let u = rng.rand();
 
                 if 1.0 - eps < u || p < eps {
                     return f64::INFINITY;
@@ -316,7 +319,7 @@ impl<AUX, BAL> UnequalProbabilitySampling
     #[inline]
     fn brewer<R>(&self, rng: &mut R) -> SamplingResult<Vec<usize>>
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         let population_size = self.population_size().get();
         let probabilities = self.probabilities().as_f64_slice();
@@ -391,7 +394,7 @@ impl<AUX, BAL> UnequalProbabilitySampling
     #[inline]
     fn poisson<R>(&self, rng: &mut R) -> Vec<usize>
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         let probabilities = self.probabilities().as_f64_slice();
         poisson_internal(rng, probabilities.as_ref())
@@ -399,7 +402,7 @@ impl<AUX, BAL> UnequalProbabilitySampling
     #[inline]
     fn conditional_poisson<R>(&self, rng: &mut R, sample_size: usize) -> SamplingResult<Vec<usize>>
     where
-        R: RandomNumberGenerator,
+        R: FloatRng,
     {
         let probabilities = self.probabilities().as_f64_slice();
         let population_size = self.population_size().get();

--- a/envisim_samplr/src/utils.rs
+++ b/envisim_samplr/src/utils.rs
@@ -14,19 +14,19 @@
 
 use std::num::NonZeroUsize;
 
-use envisim_utils::random::RandomNumberGenerator;
+use envisim_utils::random::Rand;
 
 /// Random permutation of usize [0,...,len] vector
 #[inline]
 pub fn shuffled_indices<R>(rng: &mut R, len: NonZeroUsize) -> Vec<usize>
 where
-    R: RandomNumberGenerator,
+    R: Rand<usize>,
 {
     let mut order: Vec<usize> = Vec::with_capacity(len.get());
     order.push(0);
 
     for i in 1..len.get() {
-        let j = rng.rusize_to(i + 1);
+        let j = rng.rand_to(i + 1);
         order.push(i);
         order.swap(i, j);
     }
@@ -38,12 +38,12 @@ where
 #[inline]
 pub fn poisson_internal<R>(rng: &mut R, probabilities: &[f64]) -> Vec<usize>
 where
-    R: RandomNumberGenerator,
+    R: Rand<f64>,
 {
     probabilities
         .iter()
         .enumerate()
-        .filter_map(|(i, &p)| rng.rbern(p).and_then(|b| b.then_some(i)))
+        .filter_map(|(i, &p)| (rng.rand() < p).then_some(i))
         .collect()
 }
 

--- a/envisim_samplr/tests/pivotal_method.rs
+++ b/envisim_samplr/tests/pivotal_method.rs
@@ -5,13 +5,13 @@ use test_utils::*;
 #[test]
 fn test_spm() {
     let options = Data10::options_u();
-    test_wor(|rng| options.spm(rng), &options, 1e-2, 10000);
+    test_wor(|rng| options.spm(rng), &options, 1e-2, 20000);
 }
 
 #[test]
 fn test_rpm() {
     let options = Data10::options_u();
-    test_wor(|rng| options.rpm(rng), &options, 1e-2, 10000);
+    test_wor(|rng| options.rpm(rng), &options, 1e-2, 20000);
 }
 
 #[test]

--- a/envisim_utils/CHANGELOG.md
+++ b/envisim_utils/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - MSRV: 1.85.1
 - Added dependency [`num-traits`](https://crates.io/crates/num-traits).
+- Added dependency [`rand_core`](https://crates.io/crates/rand_core).
 - Bumped optional dependency [`rand`](https://crates.io/crates/rand) to 0.10.1.
 
 ### Added
@@ -24,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added search point representation `SearchPoint`.
 - Added trait `FindSplit`, implemented for `MidpointSlide`.
 - Added `try_sys_rng` for `SmallRng`, which returns a random number generator using `rand::rngs::SysRng`.
+- Added trait `FloatRng` which extends `rand_core::Rng` with the method `next_f64`, which is needed in order to construct `Rng` from the R `unif_rand` API.
+- Added trait `Rand<N>`, which extends `Rng` to draw numbers from `N`. Implemented for primitive integers and `f64`.
+- Added trait `RandSlice<N>` which extends `Rand<N>` to draw numbers into a slice.
+- Added functions `random_element`, `random_weighted` for drawing a random element from a slice and making a weighted selection respectively.
 
 ### Changed
 - Made `Matrix` generic over `Number`. `Matrix` is now a type alias for `MatrixBase`, and represents an owned matrix. The type alias for a reference matrix is `MatrixRef`.
@@ -45,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed tree-searchers `Searcher`, `SearcherWeigthed`.
 - Removed type alias `FindSplit`.
 - Removed utility functions `usize_to_f64` and `f64_to_usize`. Use `num_traits::ToPrimitive` instead.
+- Removed trait `RandomNumberGenerator`.
 
 
 ## [0.4.0 - 2026-03-27]

--- a/envisim_utils/Cargo.toml
+++ b/envisim_utils/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 
 [dependencies]
 num-traits = "0.2.19"
+rand_core = {version="0.10.1"}
 rand = {version="0.10.1", optional = true}
 rustc-hash = "2.1.1"
 

--- a/envisim_utils/src/indices.rs
+++ b/envisim_utils/src/indices.rs
@@ -20,7 +20,10 @@ use rustc_hash::{
     FxHashMap,
 };
 
-use crate::random::RandomNumberGenerator;
+use crate::random::{
+    Rng,
+    random_element,
+};
 
 /// A struct (list) for keeping track of indices in use. The internal list keeps track, without
 /// order, of the indices.
@@ -177,9 +180,9 @@ impl Indices {
     #[inline]
     pub fn draw<R>(&self, rng: &mut R) -> Option<usize>
     where
-        R: RandomNumberGenerator,
+        R: Rng,
     {
-        rng.relement(&self.list).copied()
+        random_element(rng, &self.list).copied()
     }
 
     /// Checks if the list contains an index

--- a/envisim_utils/src/probabilities.rs
+++ b/envisim_utils/src/probabilities.rs
@@ -13,7 +13,10 @@
 use num_traits::ToPrimitive;
 
 use crate::kd_tree::searcher::WeightCollection;
-use crate::random::RandomNumberGenerator;
+use crate::random::{
+    RandomNumber,
+    RngFloat,
+};
 use crate::sampling_options::{
     ProbabilitySpec,
     ProbabilitySpecEqual,
@@ -156,7 +159,10 @@ pub trait ProbabilityStore {
     #[must_use]
     fn eq(&self, a: Self::PR, b: Self::PR) -> bool;
     #[must_use]
-    fn draw<G: RandomNumberGenerator>(&self, rng: &mut G, max: Self::PR) -> Self::PR;
+    fn draw<G>(&self, rng: &mut G, max: Self::PR) -> Self::PR
+    where
+        G: RngFloat,
+        Self::PR: RandomNumber<G>;
 }
 impl ProbabilityStore for FloatProbabilities {
     type PR = f64;
@@ -185,8 +191,12 @@ impl ProbabilityStore for FloatProbabilities {
     #[inline]
     fn eq(&self, a: Self::PR, b: Self::PR) -> bool { (a - b).abs() <= self.eps }
     #[inline]
-    fn draw<G: RandomNumberGenerator>(&self, rng: &mut G, max: Self::PR) -> Self::PR {
-        rng.rf64_to(max).expect("max to be non-negative")
+    fn draw<G>(&self, rng: &mut G, max: Self::PR) -> Self::PR
+    where
+        G: RngFloat,
+        Self::PR: RandomNumber<G>,
+    {
+        Self::PR::rand_in(rng, 0.0..max)
     }
 }
 impl ProbabilityStore for ExactProbabilities {
@@ -216,8 +226,12 @@ impl ProbabilityStore for ExactProbabilities {
     #[inline]
     fn eq(&self, a: Self::PR, b: Self::PR) -> bool { a == b }
     #[inline]
-    fn draw<G: RandomNumberGenerator>(&self, rng: &mut G, max: Self::PR) -> Self::PR {
-        rng.rusize_to(max)
+    fn draw<G>(&self, rng: &mut G, max: Self::PR) -> Self::PR
+    where
+        G: RngFloat,
+        Self::PR: RandomNumber<G>,
+    {
+        usize::rand_in(rng, 0..max)
     }
 }
 

--- a/envisim_utils/src/probabilities.rs
+++ b/envisim_utils/src/probabilities.rs
@@ -13,9 +13,10 @@
 use num_traits::ToPrimitive;
 
 use crate::kd_tree::searcher::WeightCollection;
+use crate::number_traits::Number;
 use crate::random::{
-    RandomNumber,
-    RngFloat,
+    FloatRng,
+    Rand,
 };
 use crate::sampling_options::{
     ProbabilitySpec,
@@ -124,8 +125,7 @@ impl FromIterator<usize> for ExactProbabilities {
 }
 
 pub trait ProbabilityStore {
-    type PR: num_traits::NumAssign + Copy + PartialOrd;
-    // + Default
+    type PR: Number;
 
     #[must_use]
     fn data(&self) -> &[Self::PR];
@@ -161,8 +161,7 @@ pub trait ProbabilityStore {
     #[must_use]
     fn draw<G>(&self, rng: &mut G, max: Self::PR) -> Self::PR
     where
-        G: RngFloat,
-        Self::PR: RandomNumber<G>;
+        G: FloatRng;
 }
 impl ProbabilityStore for FloatProbabilities {
     type PR = f64;
@@ -193,10 +192,9 @@ impl ProbabilityStore for FloatProbabilities {
     #[inline]
     fn draw<G>(&self, rng: &mut G, max: Self::PR) -> Self::PR
     where
-        G: RngFloat,
-        Self::PR: RandomNumber<G>,
+        G: Rand<Self::PR>,
     {
-        Self::PR::rand_in(rng, 0.0..max)
+        rng.rand_in(0.0..max)
     }
 }
 impl ProbabilityStore for ExactProbabilities {
@@ -228,10 +226,9 @@ impl ProbabilityStore for ExactProbabilities {
     #[inline]
     fn draw<G>(&self, rng: &mut G, max: Self::PR) -> Self::PR
     where
-        G: RngFloat,
-        Self::PR: RandomNumber<G>,
+        G: Rand<Self::PR>,
     {
-        usize::rand_in(rng, 0..max)
+        rng.rand_in(0..max)
     }
 }
 

--- a/envisim_utils/src/random.rs
+++ b/envisim_utils/src/random.rs
@@ -23,33 +23,49 @@
 use std::ops::Range;
 use std::slice::from_raw_parts_mut;
 
-pub use rand_core::Rng;
+pub use rand_core::{
+    Rng,
+    TryRng,
+};
 
 use crate::number_traits::Number;
 
-pub trait RngFloat: Rng {
+pub trait FloatRng: Rng {
     /// Generates the next uniform number in $[0.0, 1.0)$
     #[must_use]
     fn next_f64(&mut self) -> f64;
 }
 
-pub trait RandomNumber<R>: Number {
-    /// Generates a random number of the type.
+pub trait Rand<N>: Rng
+where
+    N: Number,
+{
+    /// Generates a random number.
     #[must_use]
-    fn rand(rng: &mut R) -> Self;
+    fn rand(&mut self) -> N;
     /// Generates a random number in a `range`.
     ///
     /// # Panics
     /// Panics if range is empty.
     #[must_use]
-    fn rand_in(rng: &mut R, range: Range<Self>) -> Self;
+    fn rand_in(&mut self, range: Range<N>) -> N;
+    /// Generates a random number in a range `0..max`.
+    ///
+    /// # Panics
+    /// Panics if range is empty.
+    #[must_use]
+    #[inline]
+    fn rand_to(&mut self, max: N) -> N { self.rand_in(N::ZERO..max) }
 }
-pub trait RandomNumberVec<R>: RandomNumber<R> {
+pub trait RandSlice<N>: Rand<N>
+where
+    N: Number,
+{
     /// Fills `dest` with random values
     #[inline]
-    fn rand_n(rng: &mut R, dest: &mut [Self]) {
+    fn rand_n(&mut self, dest: &mut [N]) {
         for v in dest.iter_mut() {
-            *v = Self::rand(rng);
+            *v = self.rand();
         }
     }
     /// Fills `dest` with random values in a `range`.
@@ -57,41 +73,47 @@ pub trait RandomNumberVec<R>: RandomNumber<R> {
     /// # Panics
     /// Panics if range is empty.
     #[inline]
-    fn rand_in_n(rng: &mut R, dest: &mut [Self], range: Range<Self>) {
+    fn rand_in_n(&mut self, dest: &mut [N], range: Range<N>) {
         assert!(!range.is_empty(), "range is empty");
         for v in dest.iter_mut() {
-            *v = Self::rand_in(rng, range.clone());
+            *v = self.rand_in(range.clone());
         }
     }
+    /// Fills `dest` with random values in a range `0..max`.
+    ///
+    /// # Panics
+    /// Panics if range is empty.
+    #[inline]
+    fn rand_to_n(&mut self, dest: &mut [N], max: N) { self.rand_in_n(dest, N::ZERO..max) }
 }
 
 /// Macro for implementing `RandomNumber` for unsigned integers
-macro_rules! random_number_impl_uint {
-    ($t:ty,$rng:ident => $rand:expr) => {
-        random_number_impl_uint!($t, $rng => $rand, vec => {});
+macro_rules! rand_impl_uint {
+    ($t:ty, $self:ident => $body:expr) => {
+        rand_impl_uint!($t, $self => $body, vec => {});
     };
-    ($t:ty,$rng:ident => $rand:expr, vec => {$($rnv_methods:item)*}) => {
-        impl<R> RandomNumber<R> for $t
+    ($t:ty, $self:ident => $body:expr, vec => {$($rnv_methods:item)*}) => {
+        impl<R> Rand<$t> for R
         where
             R: Rng,
         {
             #[inline]
-            fn rand($rng: &mut R) -> Self { $rand }
+            fn rand(&mut $self) -> $t { $body }
             #[inline]
-            fn rand_in($rng: &mut R, range: Range<Self>) -> Self {
+            fn rand_in(&mut self, range: Range<$t>) -> $t {
                 assert!(!range.is_empty());
                 let b = range.end - range.start;
-                let rem = ((Self::MAX % b) + 1) % b;
-                let m = Self::MAX - rem;
+                let rem = ((<$t>::MAX % b) + 1) % b;
+                let m = <$t>::MAX - rem;
                 loop {
-                    let u = Self::rand($rng);
+                    let u: $t = self.rand();
                     if u <= m {
                         return range.start + (u % b);
                     }
                 }
             }
         }
-        impl<R> RandomNumberVec<R> for $t
+        impl<R> RandSlice<$t> for R
         where
             R: Rng,
         {
@@ -100,32 +122,32 @@ macro_rules! random_number_impl_uint {
     };
 }
 /// Macro for implementing `RandomNumber` for signed integers
-macro_rules! random_number_impl_sint {
-    ($ts:ty,$tu:ty) => {
-        random_number_impl_sint!($ts, $tu, vec => {});
+macro_rules! rand_impl_sint {
+    ($ts:ty, $tu:ty) => {
+        rand_impl_sint!($ts, $tu, vec => {});
     };
-    ($ts:ty,$tu:ty, vec => {$($rnv_methods:item)*}) => {
-        impl<R> RandomNumber<R> for $ts
+    ($ts:ty, $tu:ty, vec => {$($rnv_methods:item)*}) => {
+        impl<R> Rand<$ts> for R
         where
             R: Rng,
         {
             #[inline]
-            fn rand(rng: &mut R) -> Self { <$tu>::rand(rng) as $ts }
+            fn rand(&mut self) -> $ts { <Self as Rand<$tu>>::rand(self) as $ts }
             #[inline]
-            fn rand_in(rng: &mut R, range: Range<Self>) -> Self {
+            fn rand_in(&mut self, range: Range<$ts>) -> $ts {
                 assert!(!range.is_empty());
                 let end = range.end as $tu;
                 let start = range.start as $tu;
                 let w = end.wrapping_sub(start);
-                range.start.wrapping_add(<$tu>::rand_in(rng, 0..w) as $ts)
+                range.start.wrapping_add(<Self as Rand<$tu>>::rand_in(self, 0..w) as $ts)
             }
         }
-        impl<R> RandomNumberVec<R> for $ts
+        impl<R> RandSlice<$ts> for R
         where
             R: Rng,
         {
             #[inline]
-            fn rand_in_n(rng: &mut R, dest: &mut [Self], range: Range<Self>)  {
+            fn rand_in_n(&mut self, dest: &mut [$ts], range: Range<$ts>)  {
                 assert!(!range.is_empty(), "range is empty");
                 if dest.is_empty() {return;}
                 let end = range.end as $tu;
@@ -138,7 +160,7 @@ macro_rules! random_number_impl_sint {
                         dest.len()
                     )
                 };
-                <$tu>::rand_in_n(rng, bytes, 0..w);
+                self.rand_in_n(bytes, 0..w);
                 for v in dest.iter_mut() {
                     *v = v.wrapping_add(range.start);
                 }
@@ -149,24 +171,24 @@ macro_rules! random_number_impl_sint {
     };
 }
 
-random_number_impl_uint!(u8, rng => rng.next_u32() as u8, vec => {
+rand_impl_uint!(u8, self => self.next_u32() as u8, vec => {
     #[inline]
-    fn rand_n(rng: &mut R, dest: &mut [Self]) {
-        rng.fill_bytes(dest);
+    fn rand_n(&mut self, dest: &mut [u8]) {
+        self.fill_bytes(dest);
     }
     #[inline]
-    fn rand_in_n(rng: &mut R, dest: &mut [Self], range: Range<Self>)  {
+    fn rand_in_n(&mut self, dest: &mut [u8], range: Range<u8>)  {
         assert!(!range.is_empty(), "range is empty");
         if dest.is_empty() {return;}
 
         let b = range.end - range.start;
-        let rem = ((Self::MAX % b) + 1) % b;
-        let m = Self::MAX - rem;
+        let rem = ((u8::MAX % b) + 1) % b;
+        let m = u8::MAX - rem;
 
         let mut i = 0;
         while i < dest.len() {
             // Fill remaining with candidates
-            rng.fill_bytes(&mut dest[i..]);
+            self.fill_bytes(&mut dest[i..]);
             let mut end = i;
             for j in i..dest.len() {
                 if dest[j] <= m {
@@ -178,9 +200,9 @@ random_number_impl_uint!(u8, rng => rng.next_u32() as u8, vec => {
         }
     }
 });
-random_number_impl_uint!(u16, rng => rng.next_u32() as u16, vec => {
+rand_impl_uint!(u16, self => self.next_u32() as u16, vec => {
     #[inline]
-    fn rand_n(rng: &mut R, dest: &mut [Self])  {
+    fn rand_n(&mut self, dest: &mut [u16])  {
         // SAFETY: u8 is half the size of u16
         let bytes = unsafe {
             from_raw_parts_mut(
@@ -188,21 +210,21 @@ random_number_impl_uint!(u16, rng => rng.next_u32() as u16, vec => {
                 dest.len() * 2
             )
         };
-        rng.fill_bytes(bytes);
+        self.fill_bytes(bytes);
     }
     #[inline]
-    fn rand_in_n(rng: &mut R, dest: &mut [Self], range: Range<Self>)  {
+    fn rand_in_n( &mut self, dest: &mut [u16], range: Range<u16>)  {
         assert!(!range.is_empty(), "range is empty");
         if dest.is_empty() {return;}
 
         let b = range.end - range.start;
-        let rem = ((Self::MAX % b) + 1) % b;
-        let m = Self::MAX - rem;
+        let rem = ((u16::MAX % b) + 1) % b;
+        let m = u16::MAX - rem;
 
         let mut i = 0;
         while i < dest.len() {
             // Fill remaining with candidates
-            Self::rand_n(rng, &mut dest[i..]);
+            self.rand_n(&mut dest[i..]);
             let mut end = i;
             for j in i..dest.len() {
                 if dest[j] <= m {
@@ -214,21 +236,21 @@ random_number_impl_uint!(u16, rng => rng.next_u32() as u16, vec => {
         }
     }
 });
-random_number_impl_uint!(u32, rng => rng.next_u32());
-random_number_impl_uint!(u64, rng => rng.next_u64());
-random_number_impl_uint!(u128, rng => {
-    let high = rng.next_u64() as u128;
-    let low = rng.next_u64() as u128;
+rand_impl_uint!(u32, self => self.next_u32());
+rand_impl_uint!(u64, self => self.next_u64());
+rand_impl_uint!(u128, self => {
+    let high = self.next_u64() as u128;
+    let low = self.next_u64() as u128;
     (high << 64) | low
 });
 #[cfg(target_pointer_width = "32")]
-random_number_impl_uint!(usize, rng => rng.next_u32() as usize);
+rand_impl_uint!(usize, self => self.next_u32() as usize);
 #[cfg(target_pointer_width = "64")]
-random_number_impl_uint!(usize, rng => rng.next_u64() as usize);
+rand_impl_uint!(usize, self => self.next_u64() as usize);
 
-random_number_impl_sint!(i8, u8, vec => {
+rand_impl_sint!(i8, u8, vec => {
     #[inline]
-    fn rand_n(rng: &mut R, dest: &mut [Self])  {
+    fn rand_n(&mut self, dest: &mut [i8])  {
         // SAFETY: i8 is the size of u8
         let bytes = unsafe {
             from_raw_parts_mut(
@@ -236,12 +258,12 @@ random_number_impl_sint!(i8, u8, vec => {
                 dest.len()
             )
         };
-        rng.fill_bytes(bytes);
+        self.fill_bytes(bytes);
     }
 });
-random_number_impl_sint!(i16, u16, vec => {
+rand_impl_sint!(i16, u16, vec => {
     #[inline]
-    fn rand_n(rng: &mut R, dest: &mut [Self])  {
+    fn rand_n(&mut self, dest: &mut [i16])  {
         // SAFETY: u8 is half the size of i16
         let bytes = unsafe {
             from_raw_parts_mut(
@@ -249,47 +271,47 @@ random_number_impl_sint!(i16, u16, vec => {
                 dest.len() * 2
             )
         };
-        rng.fill_bytes(bytes);
+        self.fill_bytes(bytes);
     }
 });
-random_number_impl_sint!(i32, u32);
-random_number_impl_sint!(i64, u64);
-random_number_impl_sint!(i128, u128);
+rand_impl_sint!(i32, u32);
+rand_impl_sint!(i64, u64);
+rand_impl_sint!(i128, u128);
 #[cfg(target_pointer_width = "32")]
-random_number_impl_sint!(isize, usize);
+rand_impl_sint!(isize, usize);
 #[cfg(target_pointer_width = "64")]
-random_number_impl_sint!(isize, usize);
+rand_impl_sint!(isize, usize);
 
-impl<R> RandomNumber<R> for f64
+impl<R> Rand<f64> for R
 where
-    R: RngFloat,
+    R: FloatRng,
 {
     #[inline]
-    fn rand(rng: &mut R) -> Self { rng.next_f64() }
+    fn rand(&mut self) -> f64 { self.next_f64() }
     #[inline]
-    fn rand_in(rng: &mut R, range: Range<Self>) -> Self {
+    fn rand_in(&mut self, range: Range<f64>) -> f64 {
         assert!(!range.is_empty(), "range is empty");
         loop {
-            let u = range.start + (range.end - range.start) * rng.next_f64();
+            let u = range.start + (range.end - range.start) * self.next_f64();
             if u < range.end {
                 return u;
             }
         }
     }
 }
-impl<R> RandomNumberVec<R> for f64 where R: RngFloat {}
+impl<R> RandSlice<f64> for R where R: FloatRng {}
 
 /// Returns a random element of a slice, or `None` if the slice is empty.
 #[must_use]
 #[inline]
 pub fn random_element<'bslice, R, T>(rng: &mut R, slice: &'bslice [T]) -> Option<&'bslice T>
 where
-    R: Rng,
+    R: Rand<usize>,
 {
     if slice.is_empty() {
         return None;
     }
-    let index = usize::rand_in(rng, 0..slice.len());
+    let index: usize = rng.rand_in(0..slice.len());
     Some(&slice[index])
 }
 
@@ -299,14 +321,14 @@ where
 #[inline]
 pub fn random_weighted<R, N>(rng: &mut R, a: N, b: N) -> Option<bool>
 where
-    R: RngFloat,
-    N: RandomNumber<R>,
+    R: Rand<N>,
+    N: Number,
 {
     let range = N::ZERO..(a + b);
     if !range.contains(&a) || !range.contains(&b) || range.is_empty() {
         return None;
     }
-    Some(N::rand_in(rng, range) < b)
+    Some(rng.rand_in(range) < b)
 }
 
 #[cfg(feature = "rand")]
@@ -314,18 +336,16 @@ mod small_rng {
     //! Implements [`RngFloat`] for [`rand::rngs::SmallRng`] if the feature `"rand"` is activated.
 
     pub use rand::SeedableRng;
-    use rand::rngs::{
-        SmallRng,
-        SysRng,
-    };
+    pub use rand::rngs::SmallRng;
+    use rand::rngs::SysRng;
     use rand::{
         RngExt,
         TryRng,
     };
 
-    use super::RngFloat;
+    use super::FloatRng;
 
-    impl RngFloat for SmallRng {
+    impl FloatRng for SmallRng {
         #[must_use]
         #[inline]
         fn next_f64(&mut self) -> f64 { self.random::<f64>() }

--- a/envisim_utils/src/random.rs
+++ b/envisim_utils/src/random.rs
@@ -11,166 +11,311 @@
 // program. If not, see <https://www.gnu.org/licenses/>.
 
 //! Provides an interface for drawing random numbers
+#![allow(
+    clippy::as_conversions,
+    clippy::cast_lossless,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss,
+    reason = "used in almost every random number function"
+)]
 
-pub trait RandomNumberGenerator {
-    /// Generates a uniform number in [`0.0`, `1.0`)
+use std::ops::Range;
+use std::slice::from_raw_parts_mut;
+
+pub use rand_core::Rng;
+
+use crate::number_traits::Number;
+
+pub trait RngFloat: Rng {
+    /// Generates the next uniform number in $[0.0, 1.0)$
     #[must_use]
-    fn rf64(&mut self) -> f64;
-    /// Generates a uniform number in [`0.0`, `b`)
+    fn next_f64(&mut self) -> f64;
+}
+
+pub trait RandomNumber<R>: Number {
+    /// Generates a random number of the type.
     #[must_use]
+    fn rand(rng: &mut R) -> Self;
+    /// Generates a random number in a `range`.
+    ///
+    /// # Panics
+    /// Panics if range is empty.
+    #[must_use]
+    fn rand_in(rng: &mut R, range: Range<Self>) -> Self;
+}
+pub trait RandomNumberVec<R>: RandomNumber<R> {
+    /// Fills `dest` with random values
     #[inline]
-    fn rf64_to(&mut self, b: f64) -> Option<f64> {
-        if 0.0 < b {
-            Some(self.rf64() * b)
-        } else if b == 0.0 {
-            Some(0.0)
-        } else {
-            None
+    fn rand_n(rng: &mut R, dest: &mut [Self]) {
+        for v in dest.iter_mut() {
+            *v = Self::rand(rng);
         }
     }
-    /// Generates a uniform number in [`a`, `b`)
-    #[must_use]
+    /// Fills `dest` with random values in a `range`.
+    ///
+    /// # Panics
+    /// Panics if range is empty.
     #[inline]
-    fn rf64_in(&mut self, a: f64, b: f64) -> Option<f64> { self.rf64_to(b - a).map(|v| v + a) }
-
-    /// Draws a random integer
-    #[must_use]
-    fn ru32(&mut self) -> u32;
-    /// Draws a number from {`0`, ..., `u32::MAX-1`}
-    #[must_use]
-    fn ru32_to(&mut self, b: u32) -> u32;
-    /// Draws a number from {`a`, ..., `b-1`}
-    #[must_use]
-    #[inline]
-    fn ru32_in(&mut self, a: u32, b: u32) -> Option<u32> {
-        (a < b).then_some(self.ru32_to(b - a) + a)
+    fn rand_in_n(rng: &mut R, dest: &mut [Self], range: Range<Self>) {
+        assert!(!range.is_empty(), "range is empty");
+        for v in dest.iter_mut() {
+            *v = Self::rand_in(rng, range.clone());
+        }
     }
+}
 
-    /// Draws a random integer
-    #[expect(
-        clippy::cast_possible_wrap,
-        clippy::as_conversions,
-        reason = "intended behaviour"
-    )]
-    #[must_use]
-    #[inline]
-    fn ri32(&mut self) -> i32 { self.ru32() as i32 }
-    /// Draws a number from {`a`, ..., `b-1`}
-    #[must_use]
-    fn ri32_in(&mut self, a: i32, b: i32) -> Option<i32>;
-
-    // Draws a random integer
-    #[must_use]
-    fn ru64(&mut self) -> u64;
-    /// Draws a number from {`0`, ..., `b-1`}
-    #[must_use]
-    fn ru64_to(&mut self, b: u64) -> u64;
-    /// Draws a number from {`a`, ..., `b-1`}
-    #[must_use]
-    #[inline]
-    fn ru64_in(&mut self, a: u64, b: u64) -> Option<u64> {
-        (a < b).then_some(self.ru64_to(b - a) + a)
-    }
-
-    /// Draws a random integer
-    #[expect(
-        clippy::cast_possible_wrap,
-        clippy::as_conversions,
-        reason = "intended behaviour"
-    )]
-    #[must_use]
-    #[inline]
-    fn ri64(&mut self) -> i64 { self.ru64() as i64 }
-    /// Draws a number from {`a`, ..., `b-1`}
-    #[must_use]
-    fn ri64_in(&mut self, a: i64, b: i64) -> Option<i64>;
-
-    // Draws a random integer
-    #[cfg(target_pointer_width = "32")]
-    #[expect(clippy::as_conversions, reason = "intended behaviour")]
-    #[must_use]
-    #[inline]
-    fn rusize(&mut self) -> usize { self.ru32() as usize }
-    /// Draws a number from {`0`, ..., `b-1`}
-    #[cfg(target_pointer_width = "32")]
-    #[expect(clippy::as_conversions, reason = "intended behaviour")]
-    #[must_use]
-    #[inline]
-    fn rusize_to(&mut self, b: usize) -> usize { self.ru32_to(b as u32) as usize }
-    /// Draws a random integer
-    #[cfg(target_pointer_width = "64")]
-    #[expect(
-        clippy::as_conversions,
-        clippy::cast_possible_truncation,
-        reason = "intended behaviour"
-    )]
-    #[must_use]
-    #[inline]
-    fn rusize(&mut self) -> usize { self.ru64() as usize }
-    /// Draws a number from {`0`, ..., `b-1`}
-    #[cfg(target_pointer_width = "64")]
-    #[expect(
-        clippy::as_conversions,
-        clippy::cast_possible_truncation,
-        reason = "intended behaviour"
-    )]
-    #[must_use]
-    #[inline]
-    fn rusize_to(&mut self, b: usize) -> usize { self.ru64_to(b as u64) as usize }
-    /// Draws a number from {`a`, ..., `b-1`}
-    #[must_use]
-    #[inline]
-    fn rusize_in(&mut self, a: usize, b: usize) -> Option<usize> {
-        (a < b).then_some(self.rusize_to(b - a) + a)
-    }
-
-    /// Returns `true` with probability `p`.
-    #[expect(
-        clippy::float_cmp,
-        reason = "0.0 and 1.0 are special cases to be handled separately"
-    )]
-    #[must_use]
-    #[inline]
-    fn rbern(&mut self, p: f64) -> Option<bool> {
-        if (0.0..=1.0).contains(&p) {
-            if p == 0.0 {
-                Some(false)
-            } else if p == 1.0 {
-                Some(true)
-            } else {
-                Some(self.rf64() < p)
+/// Macro for implementing `RandomNumber` for unsigned integers
+macro_rules! random_number_impl_uint {
+    ($t:ty,$rng:ident => $rand:expr) => {
+        random_number_impl_uint!($t, $rng => $rand, vec => {});
+    };
+    ($t:ty,$rng:ident => $rand:expr, vec => {$($rnv_methods:item)*}) => {
+        impl<R> RandomNumber<R> for $t
+        where
+            R: Rng,
+        {
+            #[inline]
+            fn rand($rng: &mut R) -> Self { $rand }
+            #[inline]
+            fn rand_in($rng: &mut R, range: Range<Self>) -> Self {
+                assert!(!range.is_empty());
+                let b = range.end - range.start;
+                let rem = ((Self::MAX % b) + 1) % b;
+                let m = Self::MAX - rem;
+                loop {
+                    let u = Self::rand($rng);
+                    if u <= m {
+                        return range.start + (u % b);
+                    }
+                }
             }
-        } else {
-            None
+        }
+        impl<R> RandomNumberVec<R> for $t
+        where
+            R: Rng,
+        {
+            $($rnv_methods)*
+        }
+    };
+}
+/// Macro for implementing `RandomNumber` for signed integers
+macro_rules! random_number_impl_sint {
+    ($ts:ty,$tu:ty) => {
+        random_number_impl_sint!($ts, $tu, vec => {});
+    };
+    ($ts:ty,$tu:ty, vec => {$($rnv_methods:item)*}) => {
+        impl<R> RandomNumber<R> for $ts
+        where
+            R: Rng,
+        {
+            #[inline]
+            fn rand(rng: &mut R) -> Self { <$tu>::rand(rng) as $ts }
+            #[inline]
+            fn rand_in(rng: &mut R, range: Range<Self>) -> Self {
+                assert!(!range.is_empty());
+                let end = range.end as $tu;
+                let start = range.start as $tu;
+                let w = end.wrapping_sub(start);
+                range.start.wrapping_add(<$tu>::rand_in(rng, 0..w) as $ts)
+            }
+        }
+        impl<R> RandomNumberVec<R> for $ts
+        where
+            R: Rng,
+        {
+            #[inline]
+            fn rand_in_n(rng: &mut R, dest: &mut [Self], range: Range<Self>)  {
+                assert!(!range.is_empty(), "range is empty");
+                if dest.is_empty() {return;}
+                let end = range.end as $tu;
+                let start = range.start as $tu;
+                let w = end.wrapping_sub(start);
+                // SAFETY: $ts is the size of $tu
+                let bytes = unsafe {
+                    from_raw_parts_mut(
+                        dest.as_mut_ptr().cast::<$tu>(),
+                        dest.len()
+                    )
+                };
+                <$tu>::rand_in_n(rng, bytes, 0..w);
+                for v in dest.iter_mut() {
+                    *v = v.wrapping_add(range.start);
+                }
+            }
+
+            $($rnv_methods)*
+        }
+    };
+}
+
+random_number_impl_uint!(u8, rng => rng.next_u32() as u8, vec => {
+    #[inline]
+    fn rand_n(rng: &mut R, dest: &mut [Self]) {
+        rng.fill_bytes(dest);
+    }
+    #[inline]
+    fn rand_in_n(rng: &mut R, dest: &mut [Self], range: Range<Self>)  {
+        assert!(!range.is_empty(), "range is empty");
+        if dest.is_empty() {return;}
+
+        let b = range.end - range.start;
+        let rem = ((Self::MAX % b) + 1) % b;
+        let m = Self::MAX - rem;
+
+        let mut i = 0;
+        while i < dest.len() {
+            // Fill remaining with candidates
+            rng.fill_bytes(&mut dest[i..]);
+            let mut end = i;
+            for j in i..dest.len() {
+                if dest[j] <= m {
+                    dest[end] = range.start + (dest[j] % b);
+                    end += 1;
+                }
+            }
+            i = end;
         }
     }
-    /// Returns a random element of a vector
-    #[must_use]
+});
+random_number_impl_uint!(u16, rng => rng.next_u32() as u16, vec => {
     #[inline]
-    fn relement<'bslice, T>(&mut self, slice: &'bslice [T]) -> Option<&'bslice T> {
-        (!slice.is_empty()).then_some(&slice[self.rusize_to(slice.len())])
+    fn rand_n(rng: &mut R, dest: &mut [Self])  {
+        // SAFETY: u8 is half the size of u16
+        let bytes = unsafe {
+            from_raw_parts_mut(
+                dest.as_mut_ptr().cast::<u8>(),
+                dest.len() * 2
+            )
+        };
+        rng.fill_bytes(bytes);
     }
-    /// Returns `Some(true)` with probability `p1 / (p0 + p1)` for two positive numbers.
-    /// Returns `None` if any number is negative, or if both are zero.
-    #[must_use]
     #[inline]
-    fn one_of_f64(&mut self, p0: f64, p1: f64) -> Option<bool> {
-        (0.0 <= p0 && 0.0 <= p1 && !(p0 == 0.0 && p1 == 0.0)).then_some(
-            self.rf64_to(p0 + p1)
-                .expect("sum of two positives to be positive")
-                < p1,
-        )
+    fn rand_in_n(rng: &mut R, dest: &mut [Self], range: Range<Self>)  {
+        assert!(!range.is_empty(), "range is empty");
+        if dest.is_empty() {return;}
+
+        let b = range.end - range.start;
+        let rem = ((Self::MAX % b) + 1) % b;
+        let m = Self::MAX - rem;
+
+        let mut i = 0;
+        while i < dest.len() {
+            // Fill remaining with candidates
+            Self::rand_n(rng, &mut dest[i..]);
+            let mut end = i;
+            for j in i..dest.len() {
+                if dest[j] <= m {
+                    dest[end] = range.start + (dest[j] % b);
+                    end += 1;
+                }
+            }
+            i = end;
+        }
     }
+});
+random_number_impl_uint!(u32, rng => rng.next_u32());
+random_number_impl_uint!(u64, rng => rng.next_u64());
+random_number_impl_uint!(u128, rng => {
+    let high = rng.next_u64() as u128;
+    let low = rng.next_u64() as u128;
+    (high << 64) | low
+});
+#[cfg(target_pointer_width = "32")]
+random_number_impl_uint!(usize, rng => rng.next_u32() as usize);
+#[cfg(target_pointer_width = "64")]
+random_number_impl_uint!(usize, rng => rng.next_u64() as usize);
+
+random_number_impl_sint!(i8, u8, vec => {
+    #[inline]
+    fn rand_n(rng: &mut R, dest: &mut [Self])  {
+        // SAFETY: i8 is the size of u8
+        let bytes = unsafe {
+            from_raw_parts_mut(
+                dest.as_mut_ptr().cast::<u8>(),
+                dest.len()
+            )
+        };
+        rng.fill_bytes(bytes);
+    }
+});
+random_number_impl_sint!(i16, u16, vec => {
+    #[inline]
+    fn rand_n(rng: &mut R, dest: &mut [Self])  {
+        // SAFETY: u8 is half the size of i16
+        let bytes = unsafe {
+            from_raw_parts_mut(
+                dest.as_mut_ptr().cast::<u8>(),
+                dest.len() * 2
+            )
+        };
+        rng.fill_bytes(bytes);
+    }
+});
+random_number_impl_sint!(i32, u32);
+random_number_impl_sint!(i64, u64);
+random_number_impl_sint!(i128, u128);
+#[cfg(target_pointer_width = "32")]
+random_number_impl_sint!(isize, usize);
+#[cfg(target_pointer_width = "64")]
+random_number_impl_sint!(isize, usize);
+
+impl<R> RandomNumber<R> for f64
+where
+    R: RngFloat,
+{
+    #[inline]
+    fn rand(rng: &mut R) -> Self { rng.next_f64() }
+    #[inline]
+    fn rand_in(rng: &mut R, range: Range<Self>) -> Self {
+        assert!(!range.is_empty(), "range is empty");
+        loop {
+            let u = range.start + (range.end - range.start) * rng.next_f64();
+            if u < range.end {
+                return u;
+            }
+        }
+    }
+}
+impl<R> RandomNumberVec<R> for f64 where R: RngFloat {}
+
+/// Returns a random element of a slice, or `None` if the slice is empty.
+#[must_use]
+#[inline]
+pub fn random_element<'bslice, R, T>(rng: &mut R, slice: &'bslice [T]) -> Option<&'bslice T>
+where
+    R: Rng,
+{
+    if slice.is_empty() {
+        return None;
+    }
+    let index = usize::rand_in(rng, 0..slice.len());
+    Some(&slice[index])
+}
+
+/// Returns `Some(true)` with probability `a / (a + b)` for two positive numbers, or `None` if all
+/// numbers are non-positive.
+#[must_use]
+#[inline]
+pub fn random_weighted<R, N>(rng: &mut R, a: N, b: N) -> Option<bool>
+where
+    R: RngFloat,
+    N: RandomNumber<R>,
+{
+    let range = N::ZERO..(a + b);
+    if !range.contains(&a) || !range.contains(&b) || range.is_empty() {
+        return None;
+    }
+    Some(N::rand_in(rng, range) < b)
 }
 
 #[cfg(feature = "rand")]
 mod small_rng {
-    //! Implements the [`RandomNumberGenerator`] for [`rand::rngs::SmallRng`] if the feature
-    //! `"rand"` is activated.
+    //! Implements [`RngFloat`] for [`rand::rngs::SmallRng`] if the feature `"rand"` is activated.
 
     pub use rand::SeedableRng;
     use rand::rngs::{
-        SmallRng as SRNG,
+        SmallRng,
         SysRng,
     };
     use rand::{
@@ -178,115 +323,22 @@ mod small_rng {
         TryRng,
     };
 
-    use super::RandomNumberGenerator;
+    use super::RngFloat;
 
-    #[must_use]
-    pub struct SmallRng(SRNG);
-
-    impl SeedableRng for SmallRng {
-        type Seed = [u8; 32];
+    impl RngFloat for SmallRng {
+        #[must_use]
         #[inline]
-        fn from_seed(seed: Self::Seed) -> Self { SmallRng(SRNG::from_seed(seed)) }
-        #[inline]
-        fn seed_from_u64(state: u64) -> Self { SmallRng(SRNG::seed_from_u64(state)) }
-    }
-    impl SmallRng {
-        /// Tries to construct a [`SmallRng`] using [`SysRng`].
-        ///
-        /// # Errors
-        /// Returns an error if rng cannot be constructed from [`SysRng`], see
-        /// [`rand::rngs::SmallRng::try_from_rng`]
-        #[inline]
-        pub fn try_sys_rng() -> Result<Self, <SysRng as TryRng>::Error> {
-            SRNG::try_from_rng(&mut SysRng).map(SmallRng)
-        }
+        fn next_f64(&mut self) -> f64 { self.random::<f64>() }
     }
 
-    impl RandomNumberGenerator for SmallRng {
-        #[inline]
-        fn rf64(&mut self) -> f64 { self.0.random::<f64>() }
-        #[inline]
-        fn ru32(&mut self) -> u32 { self.0.random::<u32>() }
-        #[inline]
-        fn ru32_to(&mut self, b: u32) -> u32 { self.0.random_range(0..b) }
-        #[inline]
-        fn ru32_in(&mut self, a: u32, b: u32) -> Option<u32> {
-            (a < b).then_some(self.0.random_range(a..b))
-        }
-        #[inline]
-        fn ri32(&mut self) -> i32 { self.0.random::<i32>() }
-        #[inline]
-        fn ri32_in(&mut self, a: i32, b: i32) -> Option<i32> { Some(self.0.random_range(a..b)) }
-        #[inline]
-        fn ru64(&mut self) -> u64 { self.0.random::<u64>() }
-        #[inline]
-        fn ru64_to(&mut self, b: u64) -> u64 { self.0.random_range(0..b) }
-        #[inline]
-        fn ru64_in(&mut self, a: u64, b: u64) -> Option<u64> {
-            (a < b).then_some(self.0.random_range(a..b))
-        }
-        #[inline]
-        fn ri64(&mut self) -> i64 { self.0.random::<i64>() }
-        #[inline]
-        fn ri64_in(&mut self, a: i64, b: i64) -> Option<i64> { Some(self.0.random_range(a..b)) }
-        #[inline]
-        fn rusize(&mut self) -> usize { self.0.random_range(0..usize::MAX) }
-        #[inline]
-        fn rusize_to(&mut self, b: usize) -> usize { self.0.random_range(0..b) }
-        #[inline]
-        fn rusize_in(&mut self, a: usize, b: usize) -> Option<usize> {
-            (a < b).then_some(self.0.random_range(a..b))
-        }
-    }
-
-    impl From<SRNG> for SmallRng {
-        #[inline]
-        fn from(rng: SRNG) -> SmallRng { SmallRng(rng) }
-    }
-
-    #[must_use]
-    pub struct SmallRngRef<'brng>(&'brng mut SRNG);
-
-    impl RandomNumberGenerator for SmallRngRef<'_> {
-        #[inline]
-        fn rf64(&mut self) -> f64 { self.0.random::<f64>() }
-        #[inline]
-        fn ru32(&mut self) -> u32 { self.0.random::<u32>() }
-        #[inline]
-        fn ru32_to(&mut self, b: u32) -> u32 { self.0.random_range(0..b) }
-        #[inline]
-        fn ru32_in(&mut self, a: u32, b: u32) -> Option<u32> {
-            (a < b).then_some(self.0.random_range(a..b))
-        }
-        #[inline]
-        fn ri32(&mut self) -> i32 { self.0.random::<i32>() }
-        #[inline]
-        fn ri32_in(&mut self, a: i32, b: i32) -> Option<i32> { Some(self.0.random_range(a..b)) }
-        #[inline]
-        fn ru64(&mut self) -> u64 { self.0.random::<u64>() }
-        #[inline]
-        fn ru64_to(&mut self, b: u64) -> u64 { self.0.random_range(0..b) }
-        #[inline]
-        fn ru64_in(&mut self, a: u64, b: u64) -> Option<u64> {
-            (a < b).then_some(self.0.random_range(a..b))
-        }
-        #[inline]
-        fn ri64(&mut self) -> i64 { self.0.random::<i64>() }
-        #[inline]
-        fn ri64_in(&mut self, a: i64, b: i64) -> Option<i64> { Some(self.0.random_range(a..b)) }
-        #[inline]
-        fn rusize(&mut self) -> usize { self.0.random_range(0..usize::MAX) }
-        #[inline]
-        fn rusize_to(&mut self, b: usize) -> usize { self.0.random_range(0..b) }
-        #[inline]
-        fn rusize_in(&mut self, a: usize, b: usize) -> Option<usize> {
-            (a < b).then_some(self.0.random_range(a..b))
-        }
-    }
-
-    impl<'brng> From<&'brng mut SRNG> for SmallRngRef<'brng> {
-        #[inline]
-        fn from(rng: &mut SRNG) -> SmallRngRef { SmallRngRef(rng) }
+    /// Tries to construct a [`SmallRng`] using [`SysRng`].
+    ///
+    /// # Errors
+    /// Returns an error if rng cannot be constructed from [`SysRng`], see
+    /// [`rand::rngs::SmallRng::try_from_rng`]
+    #[inline]
+    pub fn try_sys_rng() -> Result<SmallRng, <SysRng as TryRng>::Error> {
+        SmallRng::try_from_rng(&mut SysRng)
     }
 }
 

--- a/envisim_utils/src/sample_controller.rs
+++ b/envisim_utils/src/sample_controller.rs
@@ -21,10 +21,7 @@ use crate::probabilities::{
     ProbabilityStore,
     UnitDecisionStatus,
 };
-use crate::random::{
-    RandomNumber,
-    RngFloat,
-};
+use crate::random::FloatRng;
 use crate::sampling_options::{
     SamplingOptionsError,
     SamplingOptionsResult,
@@ -124,8 +121,7 @@ impl<PROB, TREE> SampleController<PROB, TREE> {
     ) -> <PROB as ProbabilityStore>::PR
     where
         PROB: ProbabilityStore,
-        R: RngFloat,
-        <PROB as ProbabilityStore>::PR: RandomNumber<R>,
+        R: FloatRng,
     {
         self.probabilities.draw(rng, max)
     }
@@ -200,8 +196,7 @@ impl<PROB, TREE> SampleController<PROB, TREE> {
     where
         Self: UnitRemoving,
         PROB: ProbabilityStore,
-        R: RngFloat,
-        <PROB as ProbabilityStore>::PR: RandomNumber<R>,
+        R: FloatRng,
     {
         let Some(id) = self.indices.last() else {
             return UnitDecisionStatus::Undecided;

--- a/envisim_utils/src/sample_controller.rs
+++ b/envisim_utils/src/sample_controller.rs
@@ -21,7 +21,10 @@ use crate::probabilities::{
     ProbabilityStore,
     UnitDecisionStatus,
 };
-use crate::random::RandomNumberGenerator;
+use crate::random::{
+    RandomNumber,
+    RngFloat,
+};
 use crate::sampling_options::{
     SamplingOptionsError,
     SamplingOptionsResult,
@@ -121,7 +124,8 @@ impl<PROB, TREE> SampleController<PROB, TREE> {
     ) -> <PROB as ProbabilityStore>::PR
     where
         PROB: ProbabilityStore,
-        R: RandomNumberGenerator,
+        R: RngFloat,
+        <PROB as ProbabilityStore>::PR: RandomNumber<R>,
     {
         self.probabilities.draw(rng, max)
     }
@@ -196,7 +200,8 @@ impl<PROB, TREE> SampleController<PROB, TREE> {
     where
         Self: UnitRemoving,
         PROB: ProbabilityStore,
-        R: RandomNumberGenerator,
+        R: RngFloat,
+        <PROB as ProbabilityStore>::PR: RandomNumber<R>,
     {
         let Some(id) = self.indices.last() else {
             return UnitDecisionStatus::Undecided;

--- a/envisim_utils/src/sampling_options/coordination_opts.rs
+++ b/envisim_utils/src/sampling_options/coordination_opts.rs
@@ -20,10 +20,7 @@ use super::error::{
     SamplingOptionsError,
     SamplingOptionsResult,
 };
-use crate::random::{
-    RandomNumber,
-    RngFloat,
-};
+use crate::random::Rand;
 
 #[must_use]
 #[derive(Clone, Debug)]
@@ -43,9 +40,9 @@ impl<'bcoord> CoordinationOptions<'bcoord> {
     #[inline]
     pub fn get_or<R>(&self, id: usize, rng: &mut R) -> f64
     where
-        R: RngFloat,
+        R: Rand<f64>,
     {
-        self.get(id).unwrap_or_else(|| f64::rand(rng))
+        self.get(id).unwrap_or_else(|| rng.rand())
     }
     /// Returns the stored random values
     #[must_use]

--- a/envisim_utils/src/sampling_options/coordination_opts.rs
+++ b/envisim_utils/src/sampling_options/coordination_opts.rs
@@ -20,7 +20,10 @@ use super::error::{
     SamplingOptionsError,
     SamplingOptionsResult,
 };
-use crate::random::RandomNumberGenerator;
+use crate::random::{
+    RandomNumber,
+    RngFloat,
+};
 
 #[must_use]
 #[derive(Clone, Debug)]
@@ -40,9 +43,9 @@ impl<'bcoord> CoordinationOptions<'bcoord> {
     #[inline]
     pub fn get_or<R>(&self, id: usize, rng: &mut R) -> f64
     where
-        R: RandomNumberGenerator,
+        R: RngFloat,
     {
-        self.get(id).unwrap_or_else(|| rng.rf64())
+        self.get(id).unwrap_or_else(|| f64::rand(rng))
     }
     /// Returns the stored random values
     #[must_use]

--- a/rsamplr_pkg/src/rust/src/random.rs
+++ b/rsamplr_pkg/src/rust/src/random.rs
@@ -11,10 +11,24 @@
 // program. If not, see <https://www.gnu.org/licenses/>.
 
 //! Utils for using R randomness and RNG state in rust
+#![allow(
+    clippy::as_conversions,
+    clippy::little_endian_bytes,
+    clippy::cast_lossless,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    reason = "used in almost every random number function"
+)]
 
-use std::cmp::Ordering;
+use std::convert::Infallible;
 
-pub use envisim_utils::random::RandomNumberGenerator;
+use envisim_utils::random::{
+    FloatRng,
+    Rng,
+    TryRng,
+};
 
 unsafe extern "C" {
     fn GetRNGstate();
@@ -47,98 +61,42 @@ impl Drop for RRng {
     }
 }
 
-impl RandomNumberGenerator for RRng {
+impl TryRng for RRng {
+    type Error = Infallible;
     #[inline]
-    fn rf64(&mut self) -> f64 {
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        Ok((self.next_f64() * ((1_u64 << 32) as f64)) as u32)
+    }
+    #[inline]
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        let high = self.next_u32() as u64;
+        let low = self.next_u32() as u64;
+        Ok((high << 32) | low)
+    }
+    #[inline]
+    fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error> {
+        let mut chunks = dst.chunks_exact_mut(4);
+
+        for chunk in &mut chunks {
+            let arr: &mut [u8; 4] = chunk.try_into().expect("chunk to be exactly len 4");
+            *arr = self.next_u32().to_le_bytes();
+        }
+
+        let rem = chunks.into_remainder();
+        if !rem.is_empty() {
+            let bytes = self.next_u32().to_le_bytes();
+            for (i, r) in rem.iter_mut().enumerate() {
+                *r = bytes[i];
+            }
+        }
+        Ok(())
+    }
+}
+
+impl FloatRng for RRng {
+    #[inline]
+    fn next_f64(&mut self) -> f64 {
         // SAFETY: C-R interface
         unsafe { unif_rand() }
-    }
-    #[expect(
-        clippy::cast_sign_loss,
-        clippy::as_conversions,
-        reason = "intended behaviour"
-    )]
-    #[inline]
-    fn ru32(&mut self) -> u32 { self.ri32() as u32 }
-    #[inline]
-    fn ru32_to(&mut self, b: u32) -> u32 {
-        loop {
-            let u = self.ru32();
-            let m = u32::MAX - (u32::MAX % b);
-            if u < m {
-                return u % b;
-            }
-        }
-    }
-    #[expect(
-        clippy::as_conversions,
-        clippy::cast_possible_truncation,
-        reason = "intended behaviour"
-    )]
-    #[inline]
-    fn ri32(&mut self) -> i32 {
-        let f = self.rf64() * 2.0 - 1.0;
-        (f * f64::from(i32::MAX)).floor() as i32
-    }
-    #[expect(
-        clippy::as_conversions,
-        clippy::cast_possible_truncation,
-        reason = "intended behaviour"
-    )]
-    #[inline]
-    fn ri32_in(&mut self, a: i32, b: i32) -> Option<i32> {
-        self.rf64_in(a.into(), b.into()).map(|v| v.floor() as i32)
-    }
-    #[inline]
-    fn ru64(&mut self) -> u64 {
-        let high = u64::from(self.ru32());
-        let low = u64::from(self.ru32());
-        (high << 32) | low
-    }
-    #[inline]
-    fn ru64_to(&mut self, b: u64) -> u64 {
-        loop {
-            let u = self.ru64();
-            let m = u64::MAX - (u64::MAX % b);
-            if u < m {
-                return u % b;
-            }
-        }
-    }
-    #[expect(
-        clippy::as_conversions,
-        clippy::cast_possible_wrap,
-        reason = "intended behaviour"
-    )]
-    #[inline]
-    fn ri64(&mut self) -> i64 { self.ru64() as i64 }
-    #[expect(
-        clippy::cast_sign_loss,
-        clippy::as_conversions,
-        reason = "intended behaviour"
-    )]
-    #[inline]
-    fn ri64_in(&mut self, a: i64, b: i64) -> Option<i64> {
-        match a.cmp(&b) {
-            Ordering::Greater => return None,
-            Ordering::Equal => return Some(a),
-            Ordering::Less => (),
-        };
-
-        let diff = (b as u64).wrapping_sub(a as u64);
-        // d can be 0...u32::MAX...i64::MAX / infty
-
-        if let Ok(d) = u32::try_from(diff) {
-            return Some(i64::from(self.ru32_to(d)) + a);
-        }
-
-        loop {
-            let unif = self.ru64() & 0x7FFF_FFFF_FFFF_FFFF;
-            let m_cap = u64::MAX - (u64::MAX) % diff;
-            if unif < m_cap {
-                #[expect(clippy::cast_possible_wrap, reason = "intended behaviour")]
-                return Some((unif % diff) as i64 + a);
-            }
-        }
     }
 }


### PR DESCRIPTION
Refactor of random number generation.

- Added dependency [`rand_core`](https://crates.io/crates/rand_core).

## envisim_utils
### Added
- Added trait `FloatRng` which extends `rand_core::Rng` with the method `next_f64`, which is needed in order to construct `Rng` from the R `unif_rand` API.
- Added trait `Rand<N>`, which extends `Rng` to draw numbers from `N`. Implemented for primitive integers and `f64`.
- Added trait `RandSlice<N>` which extends `Rand<N>` to draw numbers into a slice.
- Added functions `random_element`, `random_weighted` for drawing a random element from a slice and making a weighted selection respectively.

### Removed
- Removed trait `RandomNumberGenerator`.
