### PR TITLE
(feat) PointSet with generic id

### DIFF
--- a/envisim_estimate/CHANGELOG.md
+++ b/envisim_estimate/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Bumped dependency `envisim_utils`.
+
 ## [0.5.0] - 2026-05-25
 - MSRV: 1.85.1
 - Added dependency [`num-traits`](https://crates.io/crates/num-traits).

--- a/envisim_estimate/src/balance.rs
+++ b/envisim_estimate/src/balance.rs
@@ -35,7 +35,7 @@ fn balance_deviation<P>(
     data: &P,
 ) -> EstimationResult<Vec<f64>>
 where
-    P: PointSet<N = f64>,
+    P: PointSet<Id = usize, Value = f64>,
 {
     let population_size = probabilities.len();
 
@@ -84,7 +84,7 @@ pub fn balance_deviation_spreading<PO, P, BAL>(
 ) -> EstimationResult<Vec<f64>>
 where
     PO: ProbabilityOptions<Real = f64>,
-    P: PointSet<N = f64>,
+    P: PointSet<Id = usize, Value = f64>,
 {
     let p = options.probabilities().to_slice_real();
     balance_deviation(sample, &p, options.spreading().data())
@@ -113,7 +113,7 @@ pub fn balance_deviation_balancing<PO, AUX, P>(
 ) -> EstimationResult<Vec<f64>>
 where
     PO: ProbabilityOptions<Real = f64>,
-    P: PointSet<N = f64>,
+    P: PointSet<Id = usize, Value = f64>,
 {
     let p = options.probabilities().to_slice_real();
     balance_deviation(sample, &p, options.balancing().data())

--- a/envisim_estimate/src/horvitz_thompson.rs
+++ b/envisim_estimate/src/horvitz_thompson.rs
@@ -217,7 +217,7 @@ pub fn local_mean_variance<PO, P, BAL>(
 ) -> EstimationResult<f64>
 where
     PO: ProbabilityOptions<Real = f64>,
-    P: PointSet<N = f64>,
+    P: PointSet<Id = usize, Value = f64>,
 {
     let sample_size = y_values.len();
 

--- a/envisim_estimate/src/nearest_neighbour.rs
+++ b/envisim_estimate/src/nearest_neighbour.rs
@@ -36,11 +36,11 @@ use crate::error::EstimationResult;
 #[inline]
 pub fn nearest_neighbour<P>(
     y_values: &[f64],
-    sample: &[usize],
+    sample: &[P::Id],
     auxiliaries: P,
 ) -> EstimationResult<f64>
 where
-    P: PointSet<N = f64>,
+    P: PointSet<Id = usize, Value = f64>,
 {
     let population_size = auxiliaries.size().get();
     let sample_size = sample.len();

--- a/envisim_estimate/src/spatial_balance.rs
+++ b/envisim_estimate/src/spatial_balance.rs
@@ -31,7 +31,10 @@ use envisim_utils::sampling_options::{
     SpreadingOptions,
     UnequalProbabilityOptions,
 };
-use num_traits::ToPrimitive;
+use num_traits::{
+    ConstZero,
+    ToPrimitive,
+};
 use rustc_hash::{
     FxBuildHasher,
     FxHashMap,
@@ -43,16 +46,17 @@ use crate::error::EstimationResult;
 /// Calculates the pi-sums for each voronoi cell
 fn voronoi_pi_sum<P, F>(
     opts: &SpreadingOptions<P>,
-    sample: &[usize],
+    sample: &[P::Id],
     prob: F,
-) -> EstimationResult<FxHashMap<usize, f64>>
+) -> EstimationResult<FxHashMap<P::Id, P::Value>>
 where
-    P: PointSet<N = f64>,
-    F: Fn(usize) -> f64,
+    P: PointSet<Value = f64>,
+    F: Fn(P::Id) -> P::Value,
 {
     let data = opts.data();
     let sample_size = sample.len();
-    let mut pi_sums = FxHashMap::<usize, f64>::with_capacity_and_hasher(sample_size, FxBuildHasher);
+    let mut pi_sums =
+        FxHashMap::<P::Id, P::Value>::with_capacity_and_hasher(sample_size, FxBuildHasher);
 
     for &id in sample {
         let p = prob(id);
@@ -96,21 +100,22 @@ where
 
 /// Calculate the voronoi means of `data`.
 /// `sample` is an iterator over sample indices and their probability factor (1-pi)/pi
+#[expect(clippy::type_complexity, reason = "Ok complexity")]
 fn voronoi_means<P, F>(
     opts: &SpreadingOptions<P>,
-    sample: &[usize],
+    sample: &[P::Id],
     prob: F,
     balance_probabilities: bool,
-) -> EstimationResult<FxHashMap<usize, Box<[f64]>>>
+) -> EstimationResult<FxHashMap<P::Id, Box<[P::Value]>>>
 where
-    P: PointSet<N = f64>,
-    F: Fn(usize) -> f64,
+    P: PointSet<Value = f64>,
+    F: Fn(P::Id) -> P::Value,
 {
     let data = opts.data();
     let sample_size = sample.len();
     let data_cols = data.dim().get();
     let mut means =
-        FxHashMap::<usize, Box<[f64]>>::with_capacity_and_hasher(sample_size, FxBuildHasher);
+        FxHashMap::<P::Id, Box<[P::Value]>>::with_capacity_and_hasher(sample_size, FxBuildHasher);
 
     for &id in sample {
         let p_factor = prob(id);
@@ -170,9 +175,9 @@ where
 }
 
 /// Calculate the norm matrix of `data`
-fn norm_matrix<P>(data: P, balance_probabilities: bool) -> Matrix<f64>
+fn norm_matrix<P>(data: P, balance_probabilities: bool) -> Matrix<P::Value>
 where
-    P: PointSet<N = f64>,
+    P: PointSet<Value = f64>,
 {
     let data_cols = data.dim().get();
     let cols = data
@@ -209,66 +214,99 @@ where
 /// Returns (phi-vec, phi-sumish)
 #[must_use]
 #[inline]
-fn energy_distance_phi_equal<P>(matrix: &P) -> (Vec<f64>, f64)
+fn energy_distance_phi_equal<P>(matrix: &P) -> (FxHashMap<P::Id, P::Value>, P::Value)
 where
-    P: PointSet<N = f64>,
+    P: PointSet<Value = f64>,
 {
     let size = matrix.size().get();
-    let u_size = size.to_f64().expect("matrix dims to convert to f64");
-    let mut phi = vec![0.0; size];
-    let mut u_spread = 0.0;
+    let mut phi = FxHashMap::<P::Id, P::Value>::with_capacity_and_hasher(size, FxBuildHasher);
 
-    for id1 in matrix.id_iter() {
-        for id2 in matrix.id_iter().skip(id1 + 1) {
+    for (i, id1) in matrix.id_iter().enumerate() {
+        let mut phi1 = <P::Value as ConstZero>::ZERO;
+        for id2 in matrix.id_iter().take(i) {
             let dist = matrix.sq_distance_between(id1, id2).sqrt();
-            phi[id1] += dist;
-            phi[id2] += dist;
+            phi1 += dist;
+            *phi.get_mut(&id2).expect("id2 to exist in map") += dist;
         }
-        phi[id1] /= u_size;
-        u_spread += phi[id1];
+        phi.insert(id1, phi1);
     }
+
+    let u_size = size.to_f64().expect("pop size to convert to f64");
+    let mut u_spread = <P::Value as ConstZero>::ZERO;
+    for val in phi.values_mut() {
+        *val /= u_size;
+        u_spread += *val;
+    }
+
     (phi, u_spread / u_size)
 }
 /// Returns (phi-vec, phi-sumish)
 #[must_use]
 #[inline]
-fn energy_distance_phi_unequal<P>(matrix: P, probabilities: &[f64], s_size: f64) -> (Vec<f64>, f64)
+fn energy_distance_phi_unequal<P>(
+    matrix: P,
+    probabilities: &[P::Value],
+    s_size: f64,
+) -> (FxHashMap<P::Id, P::Value>, P::Value)
 where
-    P: PointSet<N = f64>,
+    P: PointSet<Id = usize, Value = f64>,
 {
-    let size = matrix.size().get();
-    let mut phi = vec![0.0; size];
-    let mut u_spread = 0.0;
+    let population_size = probabilities.len();
+    assert!(
+        population_size <= matrix.size().get(),
+        "not able to map between prob indices and PointSet"
+    );
+    let mut phi =
+        FxHashMap::<P::Id, P::Value>::with_capacity_and_hasher(population_size, FxBuildHasher);
 
-    for id1 in matrix.id_iter() {
-        for id2 in matrix.id_iter().skip(id1 + 1) {
+    let probs: Vec<f64> = probabilities.iter().map(|&p| p / s_size).collect();
+
+    for id1 in 0..population_size {
+        let mut phi1 = <P::Value as ConstZero>::ZERO;
+
+        for id2 in 0..id1 {
             let dist = matrix.sq_distance_between(id1, id2).sqrt();
-            phi[id1] += dist * probabilities[id2] / s_size;
-            phi[id2] += dist * probabilities[id1] / s_size;
+            phi1 += dist * probs[id2];
+            *phi.get_mut(&id2).expect("id2 to exist in map") += dist * probs[id1];
         }
-        u_spread += phi[id1] * probabilities[id1];
+
+        phi.insert(id1, phi1);
     }
-    (phi, u_spread / s_size)
+
+    let mut u_spread = <P::Value as ConstZero>::ZERO;
+    for (&id, val) in &mut phi {
+        // Second div. by s_size goes here
+        u_spread += *val * probs[id];
+    }
+
+    (phi, u_spread)
 }
 
 /// Returns 2 E||X-Z|| - E||X-X'||
 #[must_use]
 #[inline]
-fn energy_distance_internal<P>(sample: &[usize], matrix: P, phi: &[f64]) -> f64
+fn energy_distance_internal<P>(
+    sample: &[P::Id],
+    matrix: P,
+    phi: &FxHashMap<P::Id, P::Value>,
+) -> P::Value
 where
-    P: PointSet<N = f64>,
+    P: PointSet<Value = f64>,
 {
-    let s_size = sample.len().to_f64().expect("sample.len to convert to f64");
-    let mut s_spread: f64 = 0.0;
-    let mut inter_spread: f64 = 0.0;
+    let s_size = sample
+        .len()
+        .to_f64()
+        .expect("sample size to convert to f64");
+    let mut s_spread = <P::Value as ConstZero>::ZERO;
+    let mut inter_spread = <P::Value as ConstZero>::ZERO;
 
-    for i in 0..sample.len() {
-        let id1 = sample[i];
+    for (i, id1) in sample.iter().enumerate() {
         inter_spread += phi[id1];
 
         // Iterate over 0..i
-        for &id2 in sample.iter().take(i) {
-            s_spread += 2.0 * matrix.sq_distance_between(id1, id2).sqrt();
+        for id2 in sample.iter().take(i) {
+            let dist = matrix.sq_distance_between(*id1, *id2).sqrt();
+            s_spread += 2.0 * dist;
         }
     }
 
@@ -303,7 +341,7 @@ where
     ///
     /// # Errors
     /// If `sample` contains duplicate ids
-    fn voronoi(&self, sample: &[usize]) -> EstimationResult<f64>;
+    fn voronoi(&self, sample: &[P::Id]) -> EstimationResult<P::Value>;
     /// Local measure of spatial balance.
     ///
     /// # Examples
@@ -326,7 +364,7 @@ where
     ///
     /// # Errors
     /// If `sample` contains duplicate ids
-    fn local(&self, sample: &[usize], balance_probabilities: bool) -> EstimationResult<f64>;
+    fn local(&self, sample: &[P::Id], balance_probabilities: bool) -> EstimationResult<P::Value>;
     /// Energy distance between sample distribution and population.
     ///
     /// # Examples
@@ -341,16 +379,16 @@ where
     /// # Ok::<(), EstimationError>(())
     /// ```
     #[must_use]
-    fn energy_distance(&self, sample: &[usize]) -> f64;
+    fn energy_distance(&self, sample: &[P::Id]) -> P::Value;
 }
 
 impl<P, BAL> SpatialBalance<P>
     for SamplingOptions<EqualProbabilityOptions, SpreadingOptions<P>, BAL>
 where
-    P: PointSet<N = f64>,
+    P: PointSet<Value = f64>,
 {
     #[inline]
-    fn voronoi(&self, sample: &[usize]) -> EstimationResult<f64> {
+    fn voronoi(&self, sample: &[P::Id]) -> EstimationResult<P::Value> {
         if sample.is_empty() {
             return Ok(f64::NAN);
         }
@@ -363,7 +401,7 @@ where
         Ok(result)
     }
     #[inline]
-    fn local(&self, sample: &[usize], balance_probabilities: bool) -> EstimationResult<f64> {
+    fn local(&self, sample: &[P::Id], balance_probabilities: bool) -> EstimationResult<P::Value> {
         if sample.is_empty() {
             return Ok(f64::NAN);
         }
@@ -406,7 +444,7 @@ where
         Ok(result.sqrt())
     }
     #[inline]
-    fn energy_distance(&self, sample: &[usize]) -> f64 {
+    fn energy_distance(&self, sample: &[P::Id]) -> P::Value {
         let matrix = self.spreading().data();
         let (phi, u_spread) = energy_distance_phi_equal(matrix);
         let edi = energy_distance_internal(sample, matrix, &phi);
@@ -418,11 +456,11 @@ impl<'bprob, PROB, P, BAL> SpatialBalance<P>
     for SamplingOptions<UnequalProbabilityOptions<'bprob, PROB>, SpreadingOptions<P>, BAL>
 where
     PROB: Number,
-    P: PointSet<N = f64>,
-    UnequalProbabilityOptions<'bprob, PROB>: ProbabilityOptions<Native = PROB, Real = f64>,
+    P: PointSet<Id = usize, Value = f64>,
+    UnequalProbabilityOptions<'bprob, PROB>: ProbabilityOptions<Native = PROB, Real = P::Value>,
 {
     #[inline]
-    fn voronoi(&self, sample: &[usize]) -> EstimationResult<f64> {
+    fn voronoi(&self, sample: &[P::Id]) -> EstimationResult<P::Value> {
         if sample.is_empty() {
             return Ok(f64::NAN);
         }
@@ -435,7 +473,7 @@ where
         Ok(result)
     }
     #[inline]
-    fn local(&self, sample: &[usize], balance_probabilities: bool) -> EstimationResult<f64> {
+    fn local(&self, sample: &[P::Id], balance_probabilities: bool) -> EstimationResult<P::Value> {
         if sample.is_empty() {
             return Ok(f64::NAN);
         }
@@ -479,8 +517,9 @@ where
 
         Ok(result.sqrt())
     }
+    /// Requires that [`PointSet`] is able to map probability indices
     #[inline]
-    fn energy_distance(&self, sample: &[usize]) -> f64 {
+    fn energy_distance(&self, sample: &[P::Id]) -> P::Value {
         let matrix = self.spreading().data();
         let probs = self.probabilities().to_slice_real();
         let s_size = sample
@@ -503,22 +542,23 @@ mod test {
     fn ed_phi() {
         let m_data: Vec<f64> = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0];
         let data = MatrixRef::new(&m_data, nz(3)).unwrap();
-        let phi = energy_distance_phi_equal(&data);
-        let res: Vec<f64> = vec![
+        let (phi, _) = energy_distance_phi_equal(&data);
+        let phi_res = vec![phi[&0], phi[&1], phi[&2]];
+        let facit: Vec<f64> = vec![
             (2.0f64.sqrt() + 8.0f64.sqrt()) / 3.0f64,
             (2.0f64.sqrt() + 2.0f64.sqrt()) / 3.0f64,
             (8.0f64.sqrt() + 2.0f64.sqrt()) / 3.0f64,
         ];
 
-        assert_vec!(phi.0, res);
+        assert_vec!(phi_res, facit);
     }
     #[test]
     fn ed_internal() {
         let m_data: Vec<f64> = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0];
         let data = MatrixRef::new(&m_data, nz(3)).unwrap();
-        let phi = energy_distance_phi_equal(&data);
-        let dist = energy_distance_internal(&[1, 2], &data, &phi.0);
-        let res: f64 = 2.0 * (phi.0[1] + phi.0[2]) / 2.0 - (2.0f64.sqrt() + 2.0f64.sqrt()) / 4.0;
+        let (phi, _) = energy_distance_phi_equal(&data);
+        let dist = energy_distance_internal(&[1, 2], &data, &phi);
+        let res: f64 = 2.0 * (phi[&1] + phi[&2]) / 2.0 - (2.0f64.sqrt() + 2.0f64.sqrt()) / 4.0;
 
         assert_delta!(dist, res);
     }

--- a/envisim_samplr/CHANGELOG.md
+++ b/envisim_samplr/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Bumped dependency `envisim_utils`.
+
 ## [0.6.0] - 2026-05-25
 - MSRV: 1.85.1
 - Added dependency [`num-traits`](https://crates.io/crates/num-integer).

--- a/envisim_samplr/src/correlated_poisson.rs
+++ b/envisim_samplr/src/correlated_poisson.rs
@@ -256,11 +256,11 @@ where
     /// the same. If no random values (no coordination), the order is random.
     order: usize,
     /// The searcher to be used to find the neighbours of the selected unit
-    searcher: WeightedSearcher<P::N>,
+    searcher: WeightedSearcher<P>,
 }
 impl<'bcoord, P> SpatialStrategy<'bcoord, P>
 where
-    P: PointSet,
+    P: PointSet<Id = usize>,
 {
     /// Constructs a new CPS runner using the spatial strategy
     #[inline]
@@ -311,13 +311,13 @@ where
 /// Fins the neighbours of the selected unit, and updates their probabilities and selection status
 #[inline]
 fn spatial_update_probabilities<P>(
-    searcher: &mut WeightedSearcher<P::N>,
+    searcher: &mut WeightedSearcher<P>,
     controller: &mut SampleController<f64, Tree<'_, P>>,
     id: usize,
     probability: Probability<f64>,
     quota: f64,
 ) where
-    P: PointSet,
+    P: PointSet<Id = usize>,
 {
     if controller.indices().is_empty() {
         return;
@@ -382,7 +382,7 @@ fn spatial_update_probabilities<P>(
 
 impl<P> CorrelatedPoissonStrategy<Tree<'_, P>> for SpatialStrategy<'_, P>
 where
-    P: PointSet,
+    P: PointSet<Id = usize>,
 {
     #[must_use]
     #[inline]
@@ -437,13 +437,13 @@ where
     P: PointSet,
 {
     /// The searcher to be used to find the neighbours of the selected unit
-    searcher: WeightedSearcher<P::N>,
+    searcher: WeightedSearcher<P>,
     /// The candidates to be selected as deciding unit
     candidates: Vec<usize>,
 }
 impl<P> LocalStrategy<P>
 where
-    P: PointSet,
+    P: PointSet<Id = usize>,
 {
     /// Constructs a new CPS runner using the local strategy
     #[inline]
@@ -466,7 +466,7 @@ where
 }
 impl<P> CorrelatedPoissonStrategy<Tree<'_, P>> for LocalStrategy<P>
 where
-    P: PointSet,
+    P: PointSet<Id = usize>,
 {
     #[must_use]
     #[inline]
@@ -492,7 +492,7 @@ where
             return controller.indices().draw(rng);
         }
 
-        let mut minimum_distance = P::N::max_value();
+        let mut minimum_distance = P::Value::max_value();
         self.candidates.clear();
 
         // Loop through all remaining units
@@ -669,7 +669,7 @@ impl<R, PO, P, BAL> SpatiallyCorrelatedPoissonSampling<R>
 where
     R: SamplingOptionsRng<PO>,
     PO: ProbabilityOptions<Real = f64>,
-    P: PointSet,
+    P: PointSet<Id = usize>,
 {
     #[inline]
     fn scps(&self, rng: &mut R) -> Vec<usize> { SpatialStrategy::new(self).sample(rng) }

--- a/envisim_samplr/src/cube_method/cube.rs
+++ b/envisim_samplr/src/cube_method/cube.rs
@@ -380,11 +380,11 @@ where
     /// The spreading options, needed in order to reset the tree (used in stratified cube)
     pub(super) spreading_options: &'btree SpreadingOptions<P>,
     /// Searcher, used in tree
-    pub(super) searcher: KNearestNeighbourSearcher<P::N>,
+    pub(super) searcher: KNearestNeighbourSearcher<P>,
 }
 impl<'btree, P> LocalCubeStrategy<'btree, P>
 where
-    P: PointSet,
+    P: PointSet<Id = usize>,
 {
     /// Constructs a new cube runner using the local cube strategy
     #[inline]
@@ -412,7 +412,7 @@ where
 }
 impl<'btree, P> CubeStrategy<Tree<'btree, P>> for LocalCubeStrategy<'btree, P>
 where
-    P: PointSet,
+    P: PointSet<Id = usize>,
 {
     /// # Panics
     /// Panics if only one unit is wanted, or if more units is wanted than remains.
@@ -593,7 +593,7 @@ impl<R, PO, P, T> LocalCubeSampling<R>
 where
     R: SamplingOptionsRng<PO>,
     PO: ProbabilityOptions<Real = f64>,
-    P: PointSet,
+    P: PointSet<Id = usize>,
     T: RawData<Elem = f64>,
 {
     #[inline]

--- a/envisim_samplr/src/cube_method/stratified.rs
+++ b/envisim_samplr/src/cube_method/stratified.rs
@@ -399,7 +399,7 @@ pub fn local_cube_stratified<R, PO, P, T, STRATA>(
 where
     R: SamplingOptionsRng<PO>,
     PO: ProbabilityOptions<Real = f64>,
-    P: PointSet,
+    P: PointSet<Id = usize>,
     T: RawData<Elem = f64>,
     STRATA: Copy + Eq + Hash,
 {

--- a/envisim_samplr/src/dbd/dbd_circular.rs
+++ b/envisim_samplr/src/dbd/dbd_circular.rs
@@ -63,7 +63,7 @@ mod config {
             ed: &EnergyDistance<P>,
         ) -> Self
         where
-            P: PointSet<N = f64>,
+            P: PointSet<Id = usize, Value = f64>,
         {
             let population_size =
                 NonZeroUsize::new(sequence.len()).expect("sequence to be non-empty");
@@ -108,7 +108,7 @@ mod config {
         #[inline]
         fn reset_total_nenergy<P>(&mut self, ed: &EnergyDistance<P>) -> f64
         where
-            P: PointSet<N = f64>,
+            P: PointSet<Id = usize, Value = f64>,
         {
             self.total_nenergy = 0.0;
             for i in 0..self.tcp.n_samples().get() {
@@ -188,7 +188,7 @@ impl<P> DbdCircular<P> {
         eps: Epsilon<f64>,
     ) -> Result<Self, CircularConfiguration>
     where
-        P: PointSet<N = f64>,
+        P: PointSet<Id = usize, Value = f64>,
     {
         let sequence: Vec<usize> = matrix.id_iter().collect();
         let annealing_temperature = dbs_options.as_annealing_temperature(eps);
@@ -216,7 +216,7 @@ impl<P> DbdCircular<P> {
 
 impl<P> AnnealingDistributionalDesign for DbdCircular<P>
 where
-    P: PointSet<N = f64>,
+    P: PointSet<Id = usize, Value = f64>,
 {
     #[inline]
     fn temperature(&self) -> &AnnealingTemperature { &self.temperature }

--- a/envisim_samplr/src/dbd/dbd_tc.rs
+++ b/envisim_samplr/src/dbd/dbd_tc.rs
@@ -70,7 +70,7 @@ mod config {
             ed: &EnergyDistance<P>,
         ) -> Self
         where
-            P: PointSet<N = f64>,
+            P: PointSet<Id = usize, Value = f64>,
         {
             assert_eq!(
                 sequence.len(),
@@ -131,7 +131,7 @@ mod config {
         #[inline]
         fn reset_total_nenergy<P>(&mut self, ed: &EnergyDistance<P>) -> f64
         where
-            P: PointSet<N = f64>,
+            P: PointSet<Id = usize, Value = f64>,
         {
             self.total_nenergy = 0.0;
             for i in 0..self.tcp.n_samples().get() {
@@ -217,7 +217,7 @@ impl<P> DbdTacticalConfiguration<P> {
         eps: Epsilon<f64>,
     ) -> Result<Self, TacticalConfiguration>
     where
-        P: PointSet<N = f64>,
+        P: PointSet<Id = usize, Value = f64>,
         R: SamplingOptionsRng<EqualProbabilityOptions>,
     {
         let population_size = matrix.size();
@@ -299,7 +299,7 @@ impl<P> DbdTacticalConfiguration<P> {
 
 impl<P> AnnealingDistributionalDesign for DbdTacticalConfiguration<P>
 where
-    P: PointSet<N = f64>,
+    P: PointSet<Id = usize, Value = f64>,
 {
     #[inline]
     fn temperature(&self) -> &AnnealingTemperature { &self.temperature }

--- a/envisim_samplr/src/dbd/energy_distance.rs
+++ b/envisim_samplr/src/dbd/energy_distance.rs
@@ -36,7 +36,7 @@ impl<P> EnergyDistance<P> {
     #[inline]
     pub fn new(matrix: P, sample_size: NonZeroUsize) -> Self
     where
-        P: PointSet<N = f64>,
+        P: PointSet<Id = usize, Value = f64>,
     {
         let size = matrix.size().get();
         let u_size = size.to_f64().expect("matrix size to convert to f64");
@@ -75,7 +75,7 @@ impl<P> EnergyDistance<P> {
     #[inline]
     fn s_energy_between(&self, id1: usize, id2: usize) -> f64
     where
-        P: PointSet<N = f64>,
+        P: PointSet<Id = usize, Value = f64>,
     {
         self.matrix.sq_distance_between(id1, id2).sqrt()
     }
@@ -84,7 +84,7 @@ impl<P> EnergyDistance<P> {
     #[inline]
     pub fn relative_distance(&self, unit: usize, a: usize, b: usize) -> f64
     where
-        P: PointSet<N = f64>,
+        P: PointSet<Id = usize, Value = f64>,
     {
         self.matrix.sq_distance_between(unit, a).sqrt()
             - self.matrix.sq_distance_between(unit, b).sqrt()
@@ -94,7 +94,7 @@ impl<P> EnergyDistance<P> {
     #[inline]
     pub fn total<I>(&self, sample_iter: I) -> f64
     where
-        P: PointSet<N = f64>,
+        P: PointSet<Id = usize, Value = f64>,
         I: Iterator<Item = usize> + Clone,
     {
         let mut s_spread: f64 = 0.0;
@@ -137,7 +137,7 @@ impl<P> EnergyDistance<P> {
     #[inline]
     fn s_delta<I>(&self, sample: I, add: usize, rem: usize) -> Option<f64>
     where
-        P: PointSet<N = f64>,
+        P: PointSet<Id = usize, Value = f64>,
         I: Iterator<Item = usize> + Clone,
     {
         if add == rem {
@@ -169,7 +169,7 @@ impl<P> EnergyDistance<P> {
     #[inline]
     pub fn delta<I>(&self, sample: I, add: usize, rem: usize) -> Option<f64>
     where
-        P: PointSet<N = f64>,
+        P: PointSet<Id = usize, Value = f64>,
         I: Iterator<Item = usize> + Clone,
     {
         let inter_spread = self.i_delta(add, rem)?;

--- a/envisim_samplr/src/dbd/mod.rs
+++ b/envisim_samplr/src/dbd/mod.rs
@@ -133,7 +133,7 @@ mod dbd_trait {
         for SamplingOptions<EqualProbabilityOptions, SpreadingOptions<P>, BAL>
     where
         R: SamplingOptionsRng<EqualProbabilityOptions>,
-        P: PointSet<N = f64>,
+        P: PointSet<Id = usize, Value = f64>,
     {
         #[inline]
         fn dbd_circular(
@@ -214,7 +214,7 @@ mod dbd_trait {
         for SamplingOptions<EqualProbabilityOptions, SpreadingOptions<P>, BAL>
     where
         R: SamplingOptionsRng<EqualProbabilityOptions>,
-        P: PointSet<N = f64>,
+        P: PointSet<Id = usize, Value = f64>,
     {
         #[inline]
         fn dbd_circular_evaluator(

--- a/envisim_samplr/src/dbd/tc_parameters.rs
+++ b/envisim_samplr/src/dbd/tc_parameters.rs
@@ -151,7 +151,7 @@ pub trait DbdConfiguration {
     #[inline]
     fn nenergy_of_sample<P>(&self, ed: &EnergyDistance<P>, sample_id: usize) -> f64
     where
-        P: PointSet<N = f64>,
+        P: PointSet<Id = usize, Value = f64>,
     {
         ed.total(self.sample(sample_id))
     }

--- a/envisim_samplr/src/pivotal_method/spatial.rs
+++ b/envisim_samplr/src/pivotal_method/spatial.rs
@@ -53,10 +53,10 @@ use crate::error::{
 /// neighbours of `id_org`, they are mutual nns
 #[inline]
 fn is_mutual_nn<P>(
-    searcher: &mut NearestNeighbourSearcher<P::N>,
+    searcher: &mut NearestNeighbourSearcher<P>,
     tree: &Tree<'_, P>,
-    id_org: usize,
-    id_n: usize,
+    id_org: P::Id,
+    id_n: P::Id,
 ) -> bool
 where
     P: PointSet,
@@ -75,13 +75,13 @@ where
     P: PointSet,
 {
     /// The searcher to be used to find the neighbours of the selected unit
-    searcher: NearestNeighbourSearcher<P::N>,
+    searcher: NearestNeighbourSearcher<P>,
     /// The candidates to be selected as deciding unit
     candidates: Vec<usize>,
 }
 impl<P> LocalStrategy1<P>
 where
-    P: PointSet,
+    P: PointSet<Id = usize>,
 {
     /// Constructs a new [`PivotalRunner`]using the LPM1 strategy
     #[inline]
@@ -90,7 +90,6 @@ where
     ) -> PivotalRunner<Self, PO::Native, Tree<'_, P>>
     where
         PO: ProbabilityOptions,
-        P: PointSet,
     {
         let controller = options.to_spreading_controller();
         let searcher = NearestNeighbourSearcher::new(controller.tree().data());
@@ -106,7 +105,7 @@ where
 }
 impl<PROB, P> PivotalStrategy<PROB, Tree<'_, P>> for LocalStrategy1<P>
 where
-    P: PointSet,
+    P: PointSet<Id = usize>,
 {
     #[inline]
     fn select_pair<R>(
@@ -169,7 +168,7 @@ where
     P: PointSet,
 {
     /// The searcher to be used to find the neighbours of the selected unit
-    searcher: NearestNeighbourSearcher<P::N>,
+    searcher: NearestNeighbourSearcher<P>,
     /// The candidates to be selected as deciding unit
     candidates: Vec<usize>,
     /// History of potential minimal nns
@@ -177,7 +176,7 @@ where
 }
 impl<P> LocalStrategy1S<P>
 where
-    P: PointSet,
+    P: PointSet<Id = usize>,
 {
     /// Constructs a new [`PivotalRunner`]using the LPM1 fast strategy
     #[inline]
@@ -186,7 +185,6 @@ where
     ) -> PivotalRunner<Self, PO::Native, Tree<'_, P>>
     where
         PO: ProbabilityOptions,
-        P: PointSet,
     {
         let controller = options.to_spreading_controller();
         let searcher = NearestNeighbourSearcher::new(controller.tree().data());
@@ -204,7 +202,7 @@ where
 }
 impl<PROB, P> PivotalStrategy<PROB, Tree<'_, P>> for LocalStrategy1S<P>
 where
-    P: PointSet,
+    P: PointSet<Id = usize>,
 {
     #[inline]
     fn select_pair<R>(
@@ -294,11 +292,11 @@ where
     P: PointSet,
 {
     /// The searcher to be used to find the neighbours of the selected unit
-    searcher: NearestNeighbourSearcher<P::N>,
+    searcher: NearestNeighbourSearcher<P>,
 }
 impl<P> LocalStrategy2<P>
 where
-    P: PointSet,
+    P: PointSet<Id = usize>,
 {
     /// Constructs a new [`PivotalRunner`]using the LPM2 strategy
     #[inline]
@@ -319,7 +317,7 @@ where
 }
 impl<PROB, P> PivotalStrategy<PROB, Tree<'_, P>> for LocalStrategy2<P>
 where
-    P: PointSet,
+    P: PointSet<Id = usize>,
 {
     #[inline]
     fn select_pair<R>(
@@ -415,7 +413,7 @@ impl<R, PO, P, BAL> LocalPivotalSampling<R> for SamplingOptions<PO, SpreadingOpt
 where
     R: SamplingOptionsRng<PO>,
     PO: ProbabilityOptions,
-    P: PointSet,
+    P: PointSet<Id = usize>,
 {
     #[inline]
     fn lpm_1(&self, rng: &mut R) -> Vec<usize> { LocalStrategy1::new(self).sample(rng) }
@@ -472,7 +470,7 @@ pub fn hierarchical_lpm_2<R, PO, P, BAL>(
 where
     R: SamplingOptionsRng<PO>,
     PO: ProbabilityOptions<Real = f64>,
-    P: PointSet,
+    P: PointSet<Id = usize>,
 {
     // Check validity of probabilities and sizes
     let sizes_sum = sizes.iter().sum();

--- a/envisim_utils/CHANGELOG.md
+++ b/envisim_utils/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Added `fmt::Debug` as a supertrait of `Number`.
+- Changed `PointSet` to be generic over `Id` and `Value`, previously only `Value` (renamed from `N`).
+- Changed `FindSplit::split`, `MidpointSlide::new`, `Neighbour`, `WeightedNeighbour`, `WeightCollection` to be generic over `units` or `Id`.
+- Changed `TreeSearcher`, `SearchPoint`, `NearestNeighbourSearcher`, `KNearestNeighbourSearcher`, `WeightedSearcher` to be generic over `PointSet`.
+- Fixed bug in `Border::from_data`.
+
 ## [0.5.0] - 2026-05-25
 - MSRV: 1.85.1
 - Added dependency [`num-traits`](https://crates.io/crates/num-integer).

--- a/envisim_utils/CHANGELOG.md
+++ b/envisim_utils/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `fmt::Debug` as a supertrait of `Number`.
 - Changed `PointSet` to be generic over `Id` and `Value`, previously only `Value` (renamed from `N`).
 - Changed `FindSplit::split`, `MidpointSlide::new`, `Neighbour`, `WeightedNeighbour`, `WeightCollection` to be generic over `units` or `Id`.
-- Changed `TreeSearcher`, `SearchPoint`, `NearestNeighbourSearcher`, `KNearestNeighbourSearcher`, `WeightedSearcher` to be generic over `PointSet`.
+- Changed `TreeSearcher`, `SearchPoint`, `NearestNeighbourSearcher`, `KNearestNeighbourSearcher`, `WeightedSearcher`, `Node`, `Leaf`, `Branch` to be generic over `PointSet`.
 - Fixed bug in `Border::from_data`.
 
 ## [0.5.0] - 2026-05-25

--- a/envisim_utils/src/kd_tree/mod.rs
+++ b/envisim_utils/src/kd_tree/mod.rs
@@ -30,7 +30,6 @@ use split_methods::{
     Split,
 };
 
-use crate::number_traits::Number;
 pub use crate::spatial::PointSet;
 
 /// Tree construction trait
@@ -44,7 +43,7 @@ pub trait TreeConfig {
     #[must_use]
     fn bucket_size(&self) -> NonZeroUsize;
     #[must_use]
-    fn split_method(&self, units: &[usize]) -> Self::Split;
+    fn split_method(&self, units: &[<Self::Data as PointSet>::Id]) -> Self::Split;
 }
 
 /// A kd-tree
@@ -55,7 +54,7 @@ where
     P: PointSet,
 {
     /// The first node
-    node: Node<P::N>,
+    node: Node<P>,
     /// A reference to the data
     data: &'bdata P,
 }
@@ -67,29 +66,38 @@ where
     clippy::exhaustive_enums,
     reason = "any new node-types is a breaking change"
 )]
-pub enum Node<N> {
-    Branch(Branch<N>),
-    Leaf(Leaf),
+pub enum Node<P>
+where
+    P: PointSet,
+{
+    Branch(Branch<P>),
+    Leaf(Leaf<P>),
 }
 
 /// A `Branch` is a [`Node`] which defines a split along a dimension.
 #[must_use]
 #[derive(Clone, Debug)]
-pub struct Branch<N> {
+pub struct Branch<P>
+where
+    P: PointSet,
+{
     /// The split of the branch
-    split: Split<N>,
+    split: Split<P::Value>,
     /// The node to the left of the split
-    left: Box<Node<N>>,
+    left: Box<Node<P>>,
     /// The node to the right of the split
-    right: Box<Node<N>>,
+    right: Box<Node<P>>,
 }
 
 /// A `Leaf` is a [`Node`] which contains units.
 #[must_use]
 #[derive(Clone, Debug)]
-pub struct Leaf {
+pub struct Leaf<P>
+where
+    P: PointSet,
+{
     /// The units contained within the leaf
-    units: Vec<usize>,
+    units: Vec<P::Id>,
 }
 
 impl<'bdata, P> Tree<'bdata, P>
@@ -98,7 +106,7 @@ where
 {
     /// Constructs a new tree containing `units`, according to some `config`.
     #[inline]
-    pub fn new<C, S>(config: &'bdata C, units: &mut [usize]) -> Self
+    pub fn new<C, S>(config: &'bdata C, units: &mut [P::Id]) -> Self
     where
         C: TreeConfig<Data = P, Split = S>,
         S: FindSplit<P>,
@@ -117,8 +125,8 @@ where
     /// Returns `None` if `unit` does not exists in the tree data.
     #[must_use]
     #[inline]
-    pub fn find_leaf_of_unit(&self, unit: usize) -> Option<&Leaf> {
-        let v: Box<[P::N]> = self.data.to_boxed_slice(unit)?;
+    pub fn find_leaf_of_unit(&self, unit: P::Id) -> Option<&Leaf<P>> {
+        let v: Box<[P::Value]> = self.data.to_boxed_slice(unit)?;
         // Since data constructs the slice, find_leaf should always be Some as there can't be
         // dimension mismatch
         self.find_leaf(&v)
@@ -127,7 +135,7 @@ where
     /// Returns `None` if the dimension of `unit` does not match the dimension of the tree data.
     #[must_use]
     #[inline]
-    pub fn find_leaf(&self, unit: &[P::N]) -> Option<&Leaf> {
+    pub fn find_leaf(&self, unit: &[P::Value]) -> Option<&Leaf<P>> {
         (unit.len() == self.data.dim().get()).then(|| self.node.find_leaf(unit))
     }
     /// Iterates the leaf by a [`TreeSearcher`].
@@ -135,7 +143,7 @@ where
     #[inline]
     pub fn iterate_leafs_by<S>(&self, searcher: &mut S) -> Option<()>
     where
-        S: TreeSearcher<P::N>,
+        S: TreeSearcher<P>,
     {
         if self.data.dim().get() == searcher.point().len() {
             self.node.iterate_leafs_by(self.data, searcher)
@@ -147,8 +155,8 @@ where
     /// Returns `None` if `unit` does not exists in the tree data.
     #[must_use]
     #[inline]
-    pub fn find_leaf_of_unit_mut(&mut self, unit: usize) -> Option<&mut Leaf> {
-        let v: Box<[P::N]> = self.data.to_boxed_slice(unit)?;
+    pub fn find_leaf_of_unit_mut(&mut self, unit: P::Id) -> Option<&mut Leaf<P>> {
+        let v: Box<[P::Value]> = self.data.to_boxed_slice(unit)?;
         // Since data constructs the slice, it should always be Some
         self.find_leaf_mut(&v)
     }
@@ -156,7 +164,7 @@ where
     /// Returns `None` if the dimension of `unit` does not match the dimension of the tree data.
     #[must_use]
     #[inline]
-    pub fn find_leaf_mut(&mut self, unit: &[P::N]) -> Option<&mut Leaf> {
+    pub fn find_leaf_mut(&mut self, unit: &[P::Value]) -> Option<&mut Leaf<P>> {
         (unit.len() == self.data.dim().get()).then(|| self.node.find_leaf_mut(unit))
     }
     /// Inserts a unit into the tree.
@@ -164,7 +172,7 @@ where
     /// Returns `true` if the unit did not already exist.
     /// Does not rebalance the tree.
     #[inline]
-    pub fn insert_unit(&mut self, unit: usize) -> Option<bool> {
+    pub fn insert_unit(&mut self, unit: P::Id) -> Option<bool> {
         self.find_leaf_of_unit_mut(unit)?.insert_unit(unit).into()
     }
     /// Removes a unit from the tree.
@@ -172,19 +180,20 @@ where
     /// Returns `false` if the unit did not already exist.
     /// Does not rebalance the tree.
     #[inline]
-    pub fn remove_unit(&mut self, unit: usize) -> Option<bool> {
+    pub fn remove_unit(&mut self, unit: P::Id) -> Option<bool> {
         self.find_leaf_of_unit_mut(unit)?.remove_unit(unit).into()
     }
 }
 
-impl<N> Node<N> {
+impl<P> Node<P>
+where
+    P: PointSet,
+{
     /// Constructs a new node, by trying to find a possible split, otherwise creating a leaf.
     /// A leaf is also created if the bucket size has been fulfilled.
-    fn new<B, P, S>(config: &B, borders: S, units: &mut [usize]) -> Self
+    fn new<B, S>(config: &B, borders: S, units: &mut [P::Id]) -> Self
     where
-        N: Number,
         B: TreeConfig<Data = P, Split = S>,
-        P: PointSet<N = N>,
         S: FindSplit<P>,
     {
         // If not enough units remain, a leaf should be constructed
@@ -207,10 +216,7 @@ impl<N> Node<N> {
         .into()
     }
     /// Returns a reference to the leaf that would contain `unit`.
-    fn find_leaf(&self, unit: &[N]) -> &Leaf
-    where
-        N: Number,
-    {
+    fn find_leaf(&self, unit: &[P::Value]) -> &Leaf<P> {
         match self {
             Self::Branch(branch) => {
                 if branch.split.unit_is_left(unit) {
@@ -223,10 +229,7 @@ impl<N> Node<N> {
         }
     }
     /// Returns a mutable reference to the leaf that would contain `unit`.
-    fn find_leaf_mut(&mut self, unit: &[N]) -> &mut Leaf
-    where
-        N: Number,
-    {
+    fn find_leaf_mut(&mut self, unit: &[P::Value]) -> &mut Leaf<P> {
         match self {
             Self::Branch(branch) => {
                 if branch.split.unit_is_left(unit) {
@@ -241,11 +244,9 @@ impl<N> Node<N> {
     /// Iterates the leaf by a [`TreeSearcher`].
     #[must_use]
     #[inline]
-    fn iterate_leafs_by<P, S>(&self, data: &P, searcher: &mut S) -> Option<()>
+    fn iterate_leafs_by<S>(&self, data: &P, searcher: &mut S) -> Option<()>
     where
-        N: Number,
-        P: PointSet<N = N>,
-        S: TreeSearcher<N>,
+        S: TreeSearcher<P>,
     {
         match self {
             Self::Branch(branch) => {
@@ -271,21 +272,27 @@ impl<N> Node<N> {
         Some(())
     }
 }
-impl<N> Branch<N> {
+impl<P> Branch<P>
+where
+    P: PointSet,
+{
     /// Returns the split that defines the branch.
     #[inline]
-    pub fn split(&self) -> &Split<N> { &self.split }
+    pub fn split(&self) -> &Split<P::Value> { &self.split }
     /// Returns a reference to the node left of the split.
     #[inline]
-    pub fn left(&self) -> &Node<N> { &self.left }
+    pub fn left(&self) -> &Node<P> { &self.left }
     /// Returns a reference to the node right of the split.
     #[inline]
-    pub fn right(&self) -> &Node<N> { &self.right }
+    pub fn right(&self) -> &Node<P> { &self.right }
 }
-impl Leaf {
+impl<P> Leaf<P>
+where
+    P: PointSet,
+{
     /// Constructs a new leaf.
     #[inline]
-    fn new(units: &[usize]) -> Self {
+    fn new(units: &[P::Id]) -> Self {
         Self {
             units: units.to_vec(),
         }
@@ -293,15 +300,15 @@ impl Leaf {
     /// Returns a reference to the units in the leaf.
     #[must_use]
     #[inline]
-    pub fn units(&self) -> &[usize] { &self.units }
+    pub fn units(&self) -> &[P::Id] { &self.units }
     /// Returns `true` if the leaf contains `unit`.
     #[must_use]
     #[inline]
-    pub fn contains_unit(&self, unit: usize) -> bool { self.units.contains(&unit) }
+    pub fn contains_unit(&self, unit: P::Id) -> bool { self.units.contains(&unit) }
     /// Inserts a unit into the leaf.
     /// Returns `true` if the unit did not already exist.
     #[inline]
-    fn insert_unit(&mut self, unit: usize) -> bool {
+    fn insert_unit(&mut self, unit: P::Id) -> bool {
         if !self.contains_unit(unit) {
             self.units.push(unit);
             return true;
@@ -311,7 +318,7 @@ impl Leaf {
     /// Removes a unit from the leaf.
     /// Returns `false` if the unit did not already exist.
     #[inline]
-    fn remove_unit(&mut self, unit: usize) -> bool {
+    fn remove_unit(&mut self, unit: P::Id) -> bool {
         match self.units.iter().position(|&id| id == unit) {
             Some(idx) => {
                 self.units.swap_remove(idx);
@@ -322,19 +329,19 @@ impl Leaf {
     }
 }
 
-impl<N> From<Branch<N>> for Node<N>
+impl<P> From<Branch<P>> for Node<P>
 where
-    N: num_traits::Num + Copy,
+    P: PointSet,
 {
     #[inline]
-    fn from(branch: Branch<N>) -> Self { Node::Branch(branch) }
+    fn from(branch: Branch<P>) -> Self { Node::Branch(branch) }
 }
-impl<N> From<Leaf> for Node<N>
+impl<P> From<Leaf<P>> for Node<P>
 where
-    N: num_traits::Num + Copy,
+    P: PointSet,
 {
     #[inline]
-    fn from(leaf: Leaf) -> Self { Node::Leaf(leaf) }
+    fn from(leaf: Leaf<P>) -> Self { Node::Leaf(leaf) }
 }
 
 #[cfg(test)]

--- a/envisim_utils/src/kd_tree/searcher.rs
+++ b/envisim_utils/src/kd_tree/searcher.rs
@@ -21,6 +21,7 @@ use neighbour::{
     Neighbour,
     WeightedNeighbour,
 };
+use num_traits::ConstZero;
 
 use super::Tree;
 use crate::number_traits::Number;
@@ -35,51 +36,56 @@ pub mod neighbour {
     ///
     /// A neighbour is equal to another if their distances are the same.
     #[derive(Copy, Clone, Debug)]
-    pub struct Neighbour<N> {
+    pub struct Neighbour<Id, Value> {
         /// Id of unit
-        id: usize,
+        id: Id,
         /// Squared euclidean distance
-        distance: N,
+        distance: Value,
     }
-    impl<N> Neighbour<N> {
+    impl<Id, Value> Neighbour<Id, Value> {
         /// Returns the neighbour id.
         #[inline]
-        pub fn id(&self) -> usize { self.id }
+        pub fn id(&self) -> Id
+        where
+            Id: Copy,
+        {
+            self.id
+        }
         /// Returns the squared euclidean distance to the neighbour
         #[inline]
-        pub fn distance(&self) -> N
+        pub fn distance(&self) -> Value
         where
-            N: Copy,
+            Value: Copy,
         {
             self.distance
         }
         /// Constructs a new neighbour
         #[inline]
-        pub fn new(id: usize, distance: N) -> Self { Self { id, distance } }
+        pub fn new(id: Id, distance: Value) -> Self { Self { id, distance } }
     }
 
-    impl<N> Ord for Neighbour<N>
+    impl<Id, Value> Ord for Neighbour<Id, Value>
     where
-        N: Number,
+        Value: Number,
     {
         #[inline]
-        fn cmp(&self, other: &Self) -> Ordering { N::compare(&self.distance, &other.distance) }
+        fn cmp(&self, other: &Self) -> Ordering { Value::compare(&self.distance, &other.distance) }
     }
-    impl<N> PartialOrd for Neighbour<N>
+    impl<Id, Value> PartialOrd for Neighbour<Id, Value>
     where
-        N: Number,
+        Value: Number,
     {
         #[inline]
         fn partial_cmp(&self, other: &Self) -> Option<Ordering> { Some(self.cmp(other)) }
     }
-    impl<N> PartialEq for Neighbour<N>
+    impl<Id, Value> PartialEq for Neighbour<Id, Value>
     where
-        N: Number,
+        Value: Number,
     {
         #[inline]
         fn eq(&self, other: &Self) -> bool { self.cmp(other).is_eq() }
     }
-    impl<N> Eq for Neighbour<N> where N: Number {}
+    impl<Id, Value> Eq for Neighbour<Id, Value> where Value: Number {}
 
     /// A weighted neighbouring unit, some squared euclidean distance away
     ///
@@ -87,22 +93,27 @@ pub mod neighbour {
     /// A weighted neighbour is sorted before another if its distance is smaller, or its distance is
     /// equal but its weight is smaller.
     #[derive(Copy, Clone, Debug)]
-    pub struct WeightedNeighbour<N> {
+    pub struct WeightedNeighbour<Id, Value> {
         /// The neighbour
-        neighbour: Neighbour<N>,
+        neighbour: Neighbour<Id, Value>,
         /// The weight
         weight: f64,
     }
 
-    impl<N> WeightedNeighbour<N> {
+    impl<Id, Value> WeightedNeighbour<Id, Value> {
         /// Returns the id of the neighbour.
         #[inline]
-        pub fn id(&self) -> usize { self.neighbour.id }
+        pub fn id(&self) -> Id
+        where
+            Id: Copy,
+        {
+            self.neighbour.id
+        }
         /// Returns the squared euclidean distance to the neighbour
         #[inline]
-        pub fn distance(&self) -> N
+        pub fn distance(&self) -> Value
         where
-            N: Copy,
+            Value: Copy,
         {
             self.neighbour.distance
         }
@@ -111,14 +122,14 @@ pub mod neighbour {
         pub fn weight(&self) -> f64 { self.weight }
         /// Constructs a new weighted neighbour
         #[inline]
-        pub fn new(id: usize, distance: N, weight: f64) -> Self {
+        pub fn new(id: Id, distance: Value, weight: f64) -> Self {
             let neighbour = Neighbour::new(id, distance);
             Self { neighbour, weight }
         }
     }
-    impl<N> Ord for WeightedNeighbour<N>
+    impl<Id, Value> Ord for WeightedNeighbour<Id, Value>
     where
-        N: Number,
+        Value: Number,
     {
         #[inline]
         fn cmp(&self, other: &Self) -> Ordering {
@@ -127,123 +138,122 @@ pub mod neighbour {
                 .then(self.weight().total_cmp(&other.weight()))
         }
     }
-    impl<N> PartialOrd for WeightedNeighbour<N>
+    impl<Id, Value> PartialOrd for WeightedNeighbour<Id, Value>
     where
-        N: Number,
+        Value: Number,
     {
         #[inline]
         fn partial_cmp(&self, other: &Self) -> Option<Ordering> { Some(self.cmp(other)) }
     }
-    impl<N> PartialEq for WeightedNeighbour<N>
+    impl<Id, Value> PartialEq for WeightedNeighbour<Id, Value>
     where
-        N: Number,
+        Value: Number,
     {
         #[inline]
         fn eq(&self, other: &Self) -> bool { self.cmp(other).is_eq() }
     }
-    impl<N> Eq for WeightedNeighbour<N> where N: Number {}
+    impl<Id, Value> Eq for WeightedNeighbour<Id, Value> where Value: Number {}
 
-    pub trait NeighbourSlice {
-        fn to_neighbour_id_iter(&self) -> impl Iterator<Item = usize>;
+    pub trait NeighbourSlice<Id> {
+        fn to_neighbour_id_iter(&self) -> impl Iterator<Item = Id>;
         #[inline]
-        fn to_neighbour_ids(&self) -> Box<[usize]> {
+        fn to_neighbour_ids(&self) -> Box<[Id]> {
             self.to_neighbour_id_iter()
                 .collect::<Vec<_>>()
                 .into_boxed_slice()
         }
         #[inline]
-        fn contains_id(&self, id: usize) -> bool {
+        fn contains_id(&self, id: Id) -> bool
+        where
+            Id: Eq,
+        {
             self.to_neighbour_id_iter().any(|nid| nid == id)
         }
     }
-    impl<N> NeighbourSlice for [Neighbour<N>]
+    impl<Id, Value> NeighbourSlice<Id> for [Neighbour<Id, Value>]
     where
-        N: Copy,
+        Id: Copy,
+        Value: Copy,
     {
         #[inline]
-        fn to_neighbour_id_iter(&self) -> impl Iterator<Item = usize> {
+        fn to_neighbour_id_iter(&self) -> impl Iterator<Item = Id> {
             self.iter().map(Neighbour::id)
         }
     }
-    impl<N> NeighbourSlice for [WeightedNeighbour<N>]
+    impl<Id, Value> NeighbourSlice<Id> for [WeightedNeighbour<Id, Value>]
     where
-        N: Copy,
+        Id: Copy,
+        Value: Copy,
     {
         #[inline]
-        fn to_neighbour_id_iter(&self) -> impl Iterator<Item = usize> {
+        fn to_neighbour_id_iter(&self) -> impl Iterator<Item = Id> {
             self.iter().map(WeightedNeighbour::id)
         }
     }
 }
 
 /// A trait for searching in a kd-[`Tree`]
-pub trait TreeSearcher<N>
+pub trait TreeSearcher<P>
 where
-    N: Number,
+    P: PointSet,
 {
     /// Returns a reference to the searching point.
-    fn point(&self) -> &[N];
+    fn point(&self) -> &[P::Value];
     /// Returns `true` if the search does not need to visit a node.
-    fn is_satisfied(&self, distance: N) -> bool;
+    fn is_satisfied(&self, distance: P::Value) -> bool;
     /// A function called on the leafs of each visited node.
-    fn visit_leaf<P>(&mut self, data: &P, leaf_units: &[usize])
-    where
-        P: PointSet<N = N>;
+    fn visit_leaf(&mut self, data: &P, leaf_units: &[P::Id]);
 }
 
 /// The search point of the [`TreeSearcher`]
 #[must_use]
 #[derive(Clone, Debug)]
-pub struct SearchPoint<N> {
+pub struct SearchPoint<P>
+where
+    P: PointSet,
+{
     /// Search point
-    point: Box<[N]>,
+    point: Box<[P::Value]>,
     /// Potential id of the point
-    unit: Option<usize>,
+    unit: Option<P::Id>,
 }
-impl<N> SearchPoint<N> {
+impl<P> SearchPoint<P>
+where
+    P: PointSet,
+{
     /// Returns the search point
     #[must_use]
     #[inline]
-    pub fn point(&self) -> &[N] { &self.point }
+    pub fn point(&self) -> &[P::Value] { &self.point }
     /// Returns the potential id of the search point
     #[must_use]
     #[inline]
-    pub fn unit(&self) -> Option<usize> { self.unit }
+    pub fn unit(&self) -> Option<P::Id> { self.unit }
     /// Returns `true` if the id of `other` matches the potential id of the search point.
     #[must_use]
     #[inline]
-    pub fn is_unit(&self, other: usize) -> bool { self.unit.is_some_and(|u| u == other) }
+    pub fn is_unit(&self, other: P::Id) -> bool { self.unit.is_some_and(|u| u == other) }
     /// Constructs a new, uninitialized search point
     #[inline]
-    pub fn new(dim: NonZeroUsize) -> Self
-    where
-        N: Number,
-    {
+    pub fn new(dim: NonZeroUsize) -> Self {
         Self {
-            point: vec![N::zero(); dim.get()].into_boxed_slice(),
+            point: vec![P::Value::ZERO; dim.get()].into_boxed_slice(),
             unit: None,
         }
     }
     /// Constructs a new search point from a unit id
     /// Returns `None` if the unit does not exist in the `data`.
     #[inline]
-    pub fn from_unit<P>(data: &P, unit: usize) -> Option<Self>
-    where
-        N: Copy,
-        P: PointSet<N = N>,
-    {
+    pub fn from_unit(data: &P, unit: P::Id) -> Option<Self> {
         Some(Self {
             point: data.to_boxed_slice(unit)?,
-            unit: unit.into(),
+            unit: Some(unit),
         })
     }
     /// Constructs a new search point from a point slice
     /// Returns `None` if the point is empty.
     #[inline]
-    pub fn from_slice(point: &[N]) -> Option<Self>
-    where
-        N: Copy,
-    {
+    pub fn from_slice(point: &[P::Value]) -> Option<Self> {
         (!point.is_empty()).then(|| Self {
             point: point.into(),
             unit: None,
@@ -253,11 +263,7 @@ impl<N> SearchPoint<N> {
     /// Returns `None` if the unit does not exist in the `data`.
     #[must_use]
     #[inline]
-    pub fn set_from_unit<P>(&mut self, data: &P, unit: usize) -> Option<()>
-    where
-        N: Copy,
-        P: PointSet<N = N>,
-    {
+    pub fn set_from_unit(&mut self, data: &P, unit: P::Id) -> Option<()> {
         self.point = data.to_boxed_slice(unit)?;
         self.unit = Some(unit);
         Some(())
@@ -266,10 +272,7 @@ impl<N> SearchPoint<N> {
     /// Returns `None` if the point dimensionaliy does not match the corrent search point dim.
     #[must_use]
     #[inline]
-    pub fn set_from_slice(&mut self, point: &[N]) -> Option<()>
-    where
-        N: Copy,
-    {
+    pub fn set_from_slice(&mut self, point: &[P::Value]) -> Option<()> {
         (self.point.len() == point.len()).then(|| {
             self.point = point.into();
             self.unit = None;
@@ -280,20 +283,22 @@ impl<N> SearchPoint<N> {
 /// Searching the nearest neighbour of a unit.
 #[must_use]
 #[derive(Clone, Debug)]
-pub struct NearestNeighbourSearcher<N> {
+pub struct NearestNeighbourSearcher<P>
+where
+    P: PointSet,
+{
     /// Search point
-    point: SearchPoint<N>,
+    point: SearchPoint<P>,
     /// The neighbours, sorted ascending by distance to the [`SearchPoint`]
-    neighbours: Vec<Neighbour<N>>,
+    neighbours: Vec<Neighbour<P::Id, P::Value>>,
 }
-impl<N> NearestNeighbourSearcher<N> {
+impl<P> NearestNeighbourSearcher<P>
+where
+    P: PointSet,
+{
     /// Constructs a new, uninitialized, 1NN-searcher.
     #[inline]
-    pub fn new<T>(data: &T) -> Self
-    where
-        N: Number,
-        T: PointSet<N = N>,
-    {
+    pub fn new(data: &P) -> Self {
         Self {
             point: SearchPoint::new(data.dim()),
             neighbours: Vec::with_capacity(6),
@@ -302,11 +307,7 @@ impl<N> NearestNeighbourSearcher<N> {
     /// Constructs a new 1NN-searcher from a `unit` according to `data`.
     /// Returns `None` if the unit does not exist in `data`.
     #[inline]
-    pub fn from_unit<T>(data: &T, unit: usize) -> Option<Self>
-    where
-        N: Copy,
-        T: PointSet<N = N>,
-    {
+    pub fn from_unit(data: &P, unit: P::Id) -> Option<Self> {
         Some(Self {
             point: SearchPoint::from_unit(data, unit)?,
             neighbours: Vec::with_capacity(6),
@@ -315,10 +316,7 @@ impl<N> NearestNeighbourSearcher<N> {
     /// Constructs a new 1NN-searcher from a point.
     /// Returns `None` if the point is empty.
     #[inline]
-    pub fn from_slice(point: &[N]) -> Option<Self>
-    where
-        N: Copy,
-    {
+    pub fn from_slice(point: &[P::Value]) -> Option<Self> {
         Some(Self {
             point: SearchPoint::from_slice(point)?,
             neighbours: Vec::with_capacity(6),
@@ -329,11 +327,7 @@ impl<N> NearestNeighbourSearcher<N> {
     ///
     /// Clears the previous search.
     #[inline]
-    pub fn reset_from_unit<T>(&mut self, data: &T, unit: usize) -> Option<&mut Self>
-    where
-        N: Copy,
-        T: PointSet<N = N>,
-    {
+    pub fn reset_from_unit(&mut self, data: &P, unit: P::Id) -> Option<&mut Self> {
         self.point.set_from_unit(data, unit)?;
         self.neighbours.clear();
         Some(self)
@@ -343,10 +337,7 @@ impl<N> NearestNeighbourSearcher<N> {
     ///
     /// Clears the previous search.
     #[inline]
-    pub fn reset_from_slice(&mut self, point: &[N]) -> Option<&mut Self>
-    where
-        N: Copy,
-    {
+    pub fn reset_from_slice(&mut self, point: &[P::Value]) -> Option<&mut Self> {
         self.point.set_from_slice(point)?;
         self.neighbours.clear();
         Some(self)
@@ -355,50 +346,42 @@ impl<N> NearestNeighbourSearcher<N> {
     /// In cases of ties, all nearest neighbours are added.
     #[must_use]
     #[inline]
-    pub fn search<T>(&mut self, tree: &Tree<T>) -> Option<()>
-    where
-        N: Number,
-        T: PointSet<N = N>,
-    {
+    pub fn search(&mut self, tree: &Tree<P>) -> Option<()> {
         self.neighbours.clear();
         tree.iterate_leafs_by(self)
     }
     /// Returns the neighbours of the latest search.
     #[must_use]
     #[inline]
-    pub fn neighbours(&self) -> &[Neighbour<N>] { &self.neighbours }
+    pub fn neighbours(&self) -> &[Neighbour<P::Id, P::Value>] { &self.neighbours }
     /// Returns the maximum squared euclidean distance of the neighbours in the latest search.
     /// Returns `None` if no neighbours were found.
     #[must_use]
     #[inline]
-    pub fn max_distance(&self) -> Option<N>
-    where
-        N: Copy,
-    {
+    pub fn max_distance(&self) -> Option<P::Value> {
         self.neighbours.last().map(Neighbour::distance)
     }
 }
-impl<N> TreeSearcher<N> for NearestNeighbourSearcher<N>
+impl<P> TreeSearcher<P> for NearestNeighbourSearcher<P>
 where
-    N: Number,
+    P: PointSet,
 {
     #[must_use]
     #[inline]
-    fn point(&self) -> &[N] { self.point.point() }
+    fn point(&self) -> &[P::Value] { self.point.point() }
     #[must_use]
     #[inline]
-    fn is_satisfied(&self, distance: N) -> bool {
+    fn is_satisfied(&self, distance: P::Value) -> bool {
         // Satisfied only if enough units AND a potential unit is not further away
         // !self.neighbours.is_empty() && self.max_distance() < distance.powi(2)
         self.max_distance()
             .is_some_and(|md| md < distance * distance)
     }
     #[inline]
-    fn visit_leaf<T>(&mut self, data: &T, leaf_units: &[usize])
-    where
-        T: PointSet<N = N>,
-    {
-        let mut current_max = self.max_distance().unwrap_or(<N as Number>::max_value());
+    fn visit_leaf(&mut self, data: &P, leaf_units: &[P::Id]) {
+        let mut current_max = self
+            .max_distance()
+            .unwrap_or(<P::Value as Number>::max_value());
         for &id in leaf_units {
             if Some(id) == self.point.unit {
                 continue;
@@ -420,22 +403,24 @@ where
 /// If `k == 1`, use [`NearestNeighbourSearcher`] instead.
 #[must_use]
 #[derive(Clone, Debug)]
-pub struct KNearestNeighbourSearcher<N> {
+pub struct KNearestNeighbourSearcher<P>
+where
+    P: PointSet,
+{
     /// Search point
-    point: SearchPoint<N>,
+    point: SearchPoint<P>,
     /// The neighbours, sorted ascending by distance to the [`SearchPoint`]
-    neighbours: Vec<Neighbour<N>>,
+    neighbours: Vec<Neighbour<P::Id, P::Value>>,
     /// The `k` number of neighbours to search for.
     nominal_size: NonZeroUsize,
 }
-impl<N> KNearestNeighbourSearcher<N> {
+impl<P> KNearestNeighbourSearcher<P>
+where
+    P: PointSet,
+{
     /// Constructs a new, uninitialized, kNN-searcher.
     #[inline]
-    pub fn new<P>(k: NonZeroUsize, data: &P) -> Self
-    where
-        N: Number,
-        P: PointSet<N = N>,
-    {
+    pub fn new(k: NonZeroUsize, data: &P) -> Self {
         Self {
             point: SearchPoint::new(data.dim()),
             neighbours: Vec::with_capacity(k.get() + 6),
@@ -445,11 +430,7 @@ impl<N> KNearestNeighbourSearcher<N> {
     /// Constructs a new kNN-searcher from a `unit` according to `data`.
     /// Returns `None` if the unit does not exist in `data`.
     #[inline]
-    pub fn from_unit<T>(k: NonZeroUsize, data: &T, unit: usize) -> Option<Self>
-    where
-        N: Copy,
-        T: PointSet<N = N>,
-    {
+    pub fn from_unit(k: NonZeroUsize, data: &P, unit: P::Id) -> Option<Self> {
         Some(Self {
             point: SearchPoint::from_unit(data, unit)?,
             neighbours: Vec::with_capacity(k.get() + 6),
@@ -459,10 +440,7 @@ impl<N> KNearestNeighbourSearcher<N> {
     /// Constructs a new kNN-searcher from a point.
     /// Returns `None` if the point is empty.
     #[inline]
-    pub fn from_slice(k: NonZeroUsize, point: &[N]) -> Option<Self>
-    where
-        N: Copy,
-    {
+    pub fn from_slice(k: NonZeroUsize, point: &[P::Value]) -> Option<Self> {
         Some(Self {
             point: SearchPoint::from_slice(point)?,
             neighbours: Vec::with_capacity(k.get() + 6),
@@ -480,11 +458,7 @@ impl<N> KNearestNeighbourSearcher<N> {
     ///
     /// Clears the previous search.
     #[inline]
-    pub fn reset_from_unit<T>(&mut self, data: &T, unit: usize) -> Option<&mut Self>
-    where
-        N: Copy,
-        T: PointSet<N = N>,
-    {
+    pub fn reset_from_unit(&mut self, data: &P, unit: P::Id) -> Option<&mut Self> {
         self.point.set_from_unit(data, unit)?;
         self.neighbours.clear();
         Some(self)
@@ -494,10 +468,7 @@ impl<N> KNearestNeighbourSearcher<N> {
     ///
     /// Clears the previous search.
     #[inline]
-    pub fn reset_from_slice(&mut self, point: &[N]) -> Option<&mut Self>
-    where
-        N: Copy,
-    {
+    pub fn reset_from_slice(&mut self, point: &[P::Value]) -> Option<&mut Self> {
         self.point.set_from_slice(point)?;
         self.neighbours.clear();
         Some(self)
@@ -506,39 +477,32 @@ impl<N> KNearestNeighbourSearcher<N> {
     /// In cases of ties, all nearest neighbours are added.
     #[must_use]
     #[inline]
-    pub fn search<P>(&mut self, tree: &Tree<P>) -> Option<()>
-    where
-        N: Number,
-        P: PointSet<N = N>,
-    {
+    pub fn search(&mut self, tree: &Tree<P>) -> Option<()> {
         self.neighbours.clear();
         tree.iterate_leafs_by(self)
     }
     /// Returns the neighbours of the latest search.
     #[must_use]
     #[inline]
-    pub fn neighbours(&self) -> &[Neighbour<N>] { &self.neighbours }
+    pub fn neighbours(&self) -> &[Neighbour<P::Id, P::Value>] { &self.neighbours }
     /// Returns the maximum squared euclidean distance of the neighbours in the latest search.
     /// Returns `None` if no neighbours were found.
     #[must_use]
     #[inline]
-    pub fn max_distance(&self) -> Option<N>
-    where
-        N: Copy,
-    {
+    pub fn max_distance(&self) -> Option<P::Value> {
         self.neighbours.last().map(Neighbour::distance)
     }
 }
-impl<N> TreeSearcher<N> for KNearestNeighbourSearcher<N>
+impl<P> TreeSearcher<P> for KNearestNeighbourSearcher<P>
 where
-    N: Number,
+    P: PointSet,
 {
     #[must_use]
     #[inline]
-    fn point(&self) -> &[N] { self.point.point() }
+    fn point(&self) -> &[P::Value] { self.point.point() }
     #[must_use]
     #[inline]
-    fn is_satisfied(&self, distance: N) -> bool {
+    fn is_satisfied(&self, distance: P::Value) -> bool {
         // Satisfied only if enough units AND a potential unit is not further away
         // self.neighbours.len() >= self.nominal_size.get() && self.max_distance() <
         // distance.powi(2)
@@ -548,15 +512,14 @@ where
                 .is_some_and(|md| md < distance * distance)
     }
     #[inline]
-    fn visit_leaf<T>(&mut self, data: &T, leaf_units: &[usize])
-    where
-        T: PointSet<N = N>,
-    {
+    fn visit_leaf(&mut self, data: &P, leaf_units: &[P::Id]) {
         let original_len = self.neighbours.len();
 
         // Default to 0.0 b/c trick below.
         // self.neighbours is assumed to be sorted by distance.
-        let mut current_max = self.max_distance().unwrap_or(<N as Number>::max_value());
+        let mut current_max = self
+            .max_distance()
+            .unwrap_or(<P::Value as Number>::max_value());
         for &id in leaf_units {
             if Some(id) == self.point.unit {
                 continue;
@@ -605,25 +568,27 @@ where
 /// Searching the nearest neighbour of a unit, until the total weight of the neighbours sum to 1.0.
 #[must_use]
 #[derive(Clone, Debug)]
-pub struct WeightedSearcher<N> {
+pub struct WeightedSearcher<P>
+where
+    P: PointSet,
+{
     /// Search point
-    point: SearchPoint<N>,
+    point: SearchPoint<P>,
     /// The weight of the search point
     point_weight: f64,
     /// The neighbours, sorted ascending by distance to the [`SearchPoint`], where lower weights are
     /// sorted before higher weights in case of ties.
-    neighbours: Vec<WeightedNeighbour<N>>,
+    neighbours: Vec<WeightedNeighbour<P::Id, P::Value>>,
     /// The total weight of the neighbours
     total_weight: f64,
 }
-impl<N> WeightedSearcher<N> {
+impl<P> WeightedSearcher<P>
+where
+    P: PointSet,
+{
     /// Constructs a new, uninitialized, wNN-searcher.
     #[inline]
-    pub fn new<T>(data: &T) -> Self
-    where
-        N: Number,
-        T: PointSet<N = N>,
-    {
+    pub fn new(data: &P) -> Self {
         Self {
             point: SearchPoint::new(data.dim()),
             point_weight: 0.5,
@@ -634,11 +599,7 @@ impl<N> WeightedSearcher<N> {
     /// Constructs a new wNN-searcher from a `unit` according to `data`.
     /// Returns `None` if the unit does not exist in `data`.
     #[inline]
-    pub fn from_unit<T>(data: &T, unit: usize, weight: f64) -> Option<Self>
-    where
-        N: Copy,
-        T: PointSet<N = N>,
-    {
+    pub fn from_unit(data: &P, unit: P::Id, weight: f64) -> Option<Self> {
         if !(0.0 < weight && weight < 1.0) {
             return None;
         }
@@ -652,10 +613,7 @@ impl<N> WeightedSearcher<N> {
     /// Constructs a new wNN-searcher from a point.
     /// Returns `None` if the point is empty.
     #[inline]
-    pub fn from_slice(point: &[N], weight: f64) -> Option<Self>
-    where
-        N: Copy,
-    {
+    pub fn from_slice(point: &[P::Value], weight: f64) -> Option<Self> {
         if !(0.0 < weight && weight < 1.0) {
             return None;
         }
@@ -671,11 +629,7 @@ impl<N> WeightedSearcher<N> {
     ///
     /// Clears the previous search.
     #[inline]
-    pub fn reset_from_unit<P>(&mut self, data: &P, unit: usize, weight: f64) -> Option<&mut Self>
-    where
-        N: Copy,
-        P: PointSet<N = N>,
-    {
+    pub fn reset_from_unit(&mut self, data: &P, unit: P::Id, weight: f64) -> Option<&mut Self> {
         if !(0.0 < weight && weight < 1.0) {
             return None;
         }
@@ -690,10 +644,7 @@ impl<N> WeightedSearcher<N> {
     ///
     /// Clears the previous search.
     #[inline]
-    pub fn reset_from_slice(&mut self, point: &[N], weight: f64) -> Option<&mut Self>
-    where
-        N: Copy,
-    {
+    pub fn reset_from_slice(&mut self, point: &[P::Value], weight: f64) -> Option<&mut Self> {
         if !(0.0 < weight && weight < 1.0) {
             return None;
         }
@@ -707,11 +658,9 @@ impl<N> WeightedSearcher<N> {
     /// In cases of ties, all nearest neighbours are added.
     #[must_use]
     #[inline]
-    pub fn search<P, W>(&mut self, tree: &Tree<P>, weights: &W) -> Option<()>
+    pub fn search<W>(&mut self, tree: &Tree<P>, weights: &W) -> Option<()>
     where
-        N: Number,
-        P: PointSet<N = N>,
-        W: WeightCollection,
+        W: WeightCollection<P::Id>,
     {
         if !(0.0 < self.point_weight && self.point_weight < 1.0) {
             return None;
@@ -724,7 +673,7 @@ impl<N> WeightedSearcher<N> {
     /// Returns the neighbours of the latest search.
     #[must_use]
     #[inline]
-    pub fn neighbours(&self) -> &[WeightedNeighbour<N>] { &self.neighbours }
+    pub fn neighbours(&self) -> &[WeightedNeighbour<P::Id, P::Value>] { &self.neighbours }
     /// Returns the sum of the weight of the neighbours
     #[must_use]
     #[inline]
@@ -737,10 +686,7 @@ impl<N> WeightedSearcher<N> {
     /// Returns `None` if no neighbours were found.
     #[must_use]
     #[inline]
-    pub fn max_distance(&self) -> Option<N>
-    where
-        N: Copy,
-    {
+    pub fn max_distance(&self) -> Option<P::Value> {
         self.neighbours.last().map(WeightedNeighbour::distance)
     }
     /// Helper for calculating the potential weight, where other is assumed to be a probability.
@@ -757,14 +703,14 @@ impl<N> WeightedSearcher<N> {
     }
 }
 
-pub trait WeightCollection {
+pub trait WeightCollection<Id> {
     #[must_use]
-    fn try_get_weight(&self, id: usize) -> Option<f64>;
+    fn try_get_weight(&self, id: Id) -> Option<f64>;
     #[must_use]
     #[inline]
-    fn get_weight(&self, id: usize) -> f64 { self.try_get_weight(id).expect("id to exist") }
+    fn get_weight(&self, id: Id) -> f64 { self.try_get_weight(id).expect("id to exist") }
 }
-impl WeightCollection for &[f64] {
+impl WeightCollection<usize> for &[f64] {
     #[inline]
     fn try_get_weight(&self, id: usize) -> Option<f64> { self.get(id).copied() }
     #[inline]
@@ -776,43 +722,49 @@ impl WeightCollection for &[f64] {
 /// searches.
 #[must_use]
 #[derive(Debug)]
-struct WeightedSearcherWrapper<'borrow, N, W> {
+struct WeightedSearcherWrapper<'borrow, P, W>
+where
+    P: PointSet,
+{
     /// The (public) searcher
-    searcher: &'borrow mut WeightedSearcher<N>,
+    searcher: &'borrow mut WeightedSearcher<P>,
     /// The weights used
     weights: &'borrow W,
 }
-impl<'borrow, N, W> WeightedSearcherWrapper<'borrow, N, W> {
+impl<'borrow, P, W> WeightedSearcherWrapper<'borrow, P, W>
+where
+    P: PointSet,
+{
     /// Constructs a new wrapper around weigthed searcher
-    fn new(searcher: &'borrow mut WeightedSearcher<N>, weights: &'borrow W) -> Self {
+    fn new(searcher: &'borrow mut WeightedSearcher<P>, weights: &'borrow W) -> Self {
         Self { searcher, weights }
     }
 }
-impl<N, W> TreeSearcher<N> for WeightedSearcherWrapper<'_, N, W>
+impl<P, W> TreeSearcher<P> for WeightedSearcherWrapper<'_, P, W>
 where
-    N: Number,
-    W: WeightCollection,
+    P: PointSet,
+    W: WeightCollection<P::Id>,
 {
     #[must_use]
     #[inline]
-    fn point(&self) -> &[N] { self.searcher.point.point() }
+    fn point(&self) -> &[P::Value] { self.searcher.point.point() }
     #[must_use]
     #[inline]
-    fn is_satisfied(&self, distance: N) -> bool {
+    fn is_satisfied(&self, distance: P::Value) -> bool {
         self.searcher.total_weight >= 1.0
             && self
                 .searcher
                 .max_distance()
                 .is_some_and(|md| md < distance * distance)
     }
-    fn visit_leaf<T>(&mut self, data: &T, leaf_units: &[usize])
-    where
-        T: PointSet<N = N>,
-    {
+    fn visit_leaf(&mut self, data: &P, leaf_units: &[P::Id]) {
         let original_len = self.searcher.neighbours.len();
 
         // Default to 0.0 b/c trick below
-        let mut current_max = self.searcher.max_distance().unwrap_or(N::zero());
+        let mut current_max = self
+            .searcher
+            .max_distance()
+            .unwrap_or(<P::Value as ConstZero>::ZERO);
         for &id in leaf_units {
             if Some(id) == self.searcher.point.unit {
                 continue;

--- a/envisim_utils/src/kd_tree/split_methods.rs
+++ b/envisim_utils/src/kd_tree/split_methods.rs
@@ -14,6 +14,7 @@
 //!
 //! A split method defines a splitting strategy for a kd-tree.
 
+use num_traits::ConstZero;
 pub use split::{
     Split,
     SplitUnit,
@@ -117,10 +118,10 @@ mod split {
         /// Sorts units according to the split, and sets unit so that it represents the index of the
         /// first unit to the right.
         #[inline]
-        pub(super) fn set_unit<T>(&mut self, data: &T, units: &mut [usize])
+        pub(super) fn set_unit<P>(&mut self, data: &P, units: &mut [P::Id])
         where
             N: Number,
-            T: PointSet<N = N>,
+            P: PointSet<Value = N>,
         {
             let mut left: usize = 0;
             let mut right: usize = units.len();
@@ -281,17 +282,18 @@ impl<N> Border<N> {
     }
     /// Constructs a new border from the `units` according to `data` in a certain dimension `dim`.
     #[inline]
-    fn from_data<T>(data: &T, units: &[usize], dim: usize) -> Self
+    fn from_data<P>(data: &P, units: &[P::Id], dim: usize) -> Self
     where
         N: Number,
-        T: PointSet<N = N>,
+        P: PointSet<Value = N>,
     {
         if units.is_empty() {
             return Self::default();
         }
+        let val0 = units[0];
         let mut b = Self {
-            min: data.coord(0, dim),
-            max: data.coord(0, dim),
+            min: data.coord(val0, dim),
+            max: data.coord(val0, dim),
         };
         for &id in units.iter().skip(1) {
             b.set_min(data.coord(id, dim));
@@ -314,25 +316,25 @@ where
 }
 
 /// Splits the data into left and right according to some algorithm.
-pub trait FindSplit<T>
+pub trait FindSplit<P>
 where
     Self: Sized,
-    T: PointSet,
+    P: PointSet,
 {
     /// Returns the split as:
     /// `SplitUnit`, the split and index of first right-unit.
     /// The left and right splits.
-    fn split(self, data: &T, units: &mut [usize]) -> Option<(SplitUnit<T::N>, Self, Self)>;
+    fn split(self, data: &P, units: &mut [P::Id]) -> Option<(SplitUnit<P::Value>, Self, Self)>;
 }
 
-impl<T> FindSplit<T> for MidpointSlide<T::N>
+impl<P> FindSplit<P> for MidpointSlide<P::Value>
 where
     Self: Sized,
-    T: PointSet,
+    P: PointSet,
 {
     #[must_use]
     #[inline]
-    fn split(mut self, data: &T, units: &mut [usize]) -> Option<(SplitUnit<T::N>, Self, Self)> {
+    fn split(mut self, data: &P, units: &mut [P::Id]) -> Option<(SplitUnit<P::Value>, Self, Self)> {
         let split = self.find_split(data, units)?;
         let mut left = self.clone();
         let mut right = self;
@@ -364,10 +366,10 @@ pub struct MidpointSlide<N> {
 impl<N> MidpointSlide<N> {
     /// Constructs a new base window from the `units` according to `data`.
     #[inline]
-    pub fn new<T>(data: &T, units: &[usize]) -> Self
+    pub fn new<P>(data: &P, units: &[P::Id]) -> Self
     where
         N: Number,
-        T: PointSet<N = N>,
+        P: PointSet<Value = N>,
     {
         Self {
             borders: (0..data.dim().get())
@@ -390,10 +392,10 @@ impl<N> MidpointSlide<N> {
     /// Redraw borders for a dimension. Returns `true` if borders are not degenerate
     #[must_use]
     #[inline]
-    fn redraw<T>(&mut self, dim: usize, data: &T, units: &[usize]) -> bool
+    fn redraw<P>(&mut self, dim: usize, data: &P, units: &[P::Id]) -> bool
     where
         N: Number,
-        T: PointSet<N = N>,
+        P: PointSet<Value = N>,
     {
         self.borders[dim] = Border::from_data(data, units, dim);
         self.borders[dim].min != self.borders[dim].max
@@ -416,10 +418,10 @@ impl<N> MidpointSlide<N> {
     /// Will panic if data dimensions does not match the number of borders in the split.
     /// This implies that the split is run on different data than for the previous split.
     #[must_use]
-    fn find_split<T>(&mut self, data: &T, units: &mut [usize]) -> Option<SplitUnit<N>>
+    fn find_split<P>(&mut self, data: &P, units: &mut [P::Id]) -> Option<SplitUnit<P::Value>>
     where
         N: Number,
-        T: PointSet<N = N>,
+        P: PointSet<Value = N>,
     {
         assert_eq!(
             data.dim().get(),
@@ -431,7 +433,7 @@ impl<N> MidpointSlide<N> {
             return None;
         }
 
-        let mut split = SplitUnit::new(0, N::zero(), true, 0);
+        let mut split = SplitUnit::new(0, <P::Value as ConstZero>::ZERO, true, 0);
 
         // Sort dims by range
         for &dim in &self.order() {

--- a/envisim_utils/src/matrix/mod.rs
+++ b/envisim_utils/src/matrix/mod.rs
@@ -586,7 +586,8 @@ where
     T: RawData<Elem = N>,
     N: Number,
 {
-    type N = N;
+    type Value = N;
+    type Id = usize;
     /// Returns the number of rows in the matrix
     #[inline]
     fn size(&self) -> NonZeroUsize { self.dims.rows }

--- a/envisim_utils/src/number_traits.rs
+++ b/envisim_utils/src/number_traits.rs
@@ -13,7 +13,10 @@
 //! Provides a trait [`Number`], extending `num_traits`
 
 use std::cmp::Ordering;
-use std::fmt::Display;
+use std::fmt::{
+    Debug,
+    Display,
+};
 
 use num_integer::Integer;
 use num_traits::{
@@ -28,7 +31,7 @@ use crate::Epsilon;
 
 /// An extension of [`num_traits::NumAssign`]
 pub trait Number:
-    Sized + Copy + PartialOrd + PartialEq + NumAssign + NumCast + ConstZero + ConstOne + Display
+    Sized + Copy + PartialOrd + PartialEq + NumAssign + NumCast + ConstZero + ConstOne + Debug + Display
 {
     const DEFAULT_EPSILON_VALUE: Self;
 

--- a/envisim_utils/src/probabilities.rs
+++ b/envisim_utils/src/probabilities.rs
@@ -439,7 +439,7 @@ impl<N> ProbabilitySet<N> {
     }
 }
 
-impl<N> WeightCollection for ProbabilitySet<N>
+impl<N> WeightCollection<usize> for ProbabilitySet<N>
 where
     N: Number,
 {

--- a/envisim_utils/src/sample_controller.rs
+++ b/envisim_utils/src/sample_controller.rs
@@ -224,7 +224,7 @@ impl<PROB> SampleController<PROB, ()> {
 
 impl<'bspread, PROB, P> SampleController<PROB, Tree<'bspread, P>>
 where
-    P: PointSet,
+    P: PointSet<Id = usize>,
 {
     #[inline]
     pub fn new_spreading(
@@ -263,7 +263,7 @@ impl<PROB> UnitRemoving for SampleController<PROB, ()> {
 }
 impl<PROB, P> UnitRemoving for SampleController<PROB, Tree<'_, P>>
 where
-    P: PointSet,
+    P: PointSet<Id = usize>,
 {
     #[inline]
     fn unit_remove(&mut self, idx: usize) -> bool {

--- a/envisim_utils/src/sampling_options/mod.rs
+++ b/envisim_utils/src/sampling_options/mod.rs
@@ -235,7 +235,7 @@ where
 impl<PO, AUXP, BAL> SamplingOptions<PO, SpreadingOptions<AUXP>, BAL>
 where
     PO: ProbabilityOptions,
-    AUXP: PointSet,
+    AUXP: PointSet<Id = usize>,
 {
     /// Constructs a [`SampleController`] containing a KD-tree from the probability specification.
     #[inline]

--- a/envisim_utils/src/sampling_options/spreading_opts.rs
+++ b/envisim_utils/src/sampling_options/spreading_opts.rs
@@ -84,7 +84,7 @@ impl<P> SpreadingOptions<P> {
     where
         P: PointSet,
     {
-        let mut units: Vec<usize> = self.data.id_iter().collect();
+        let mut units: Vec<P::Id> = self.data.id_iter().collect();
         Tree::new(self, &mut units)
     }
 }
@@ -102,11 +102,11 @@ where
     P: PointSet,
 {
     type Data = P;
-    type Split = MidpointSlide<P::N>;
+    type Split = MidpointSlide<P::Value>;
     #[inline]
     fn data(&self) -> &Self::Data { &self.data }
     #[inline]
     fn bucket_size(&self) -> NonZeroUsize { self.bucket_size }
     #[inline]
-    fn split_method(&self, units: &[usize]) -> Self::Split { MidpointSlide::new(&self.data, units) }
+    fn split_method(&self, units: &[P::Id]) -> Self::Split { MidpointSlide::new(&self.data, units) }
 }

--- a/envisim_utils/src/spatial.rs
+++ b/envisim_utils/src/spatial.rs
@@ -12,6 +12,8 @@
 
 //! Provides the `PointSet` trait
 
+use std::fmt::Debug;
+use std::hash::Hash;
 use std::num::NonZeroUsize;
 
 use num_traits::ConstZero;
@@ -19,37 +21,38 @@ use num_traits::ConstZero;
 use crate::number_traits::Number;
 
 pub trait PointSet {
-    type N: Number;
+    type Id: Sized + Eq + Hash + Ord + Copy + Debug;
+    type Value: Number;
 
     /// Number of points in set
     #[must_use]
     fn size(&self) -> NonZeroUsize;
     /// Iterator over point ids
     #[must_use]
-    fn id_iter(&self) -> impl Iterator<Item = usize>;
+    fn id_iter(&self) -> impl Iterator<Item = Self::Id>;
     /// Dimensions of point
     #[must_use]
     fn dim(&self) -> NonZeroUsize;
     /// Returns true of point id exists
     #[must_use]
-    fn exists(&self, id: usize) -> bool;
+    fn exists(&self, id: Self::Id) -> bool;
     /// Returns the dimension value of point `id`
     #[must_use]
     #[inline]
-    fn coord(&self, id: usize, dim: usize) -> Self::N {
+    fn coord(&self, id: Self::Id, dim: usize) -> Self::Value {
         self.try_coord(id, dim).expect("valid id and dim")
     }
     #[must_use]
-    fn try_coord(&self, id: usize, dim: usize) -> Option<Self::N>;
+    fn try_coord(&self, id: Self::Id, dim: usize) -> Option<Self::Value>;
     #[must_use]
     #[inline]
-    fn sq_distance(&self, id: usize, point: &[Self::N]) -> Self::N {
+    fn sq_distance(&self, id: Self::Id, point: &[Self::Value]) -> Self::Value {
         assert_eq!(
             point.len(),
             self.dim().get(),
             "point dimensions must match set dimension"
         );
-        let mut sum = <Self::N as ConstZero>::ZERO;
+        let mut sum = <Self::Value as ConstZero>::ZERO;
         for (d, &p) in point.iter().enumerate() {
             let diff = p - self.coord(id, d);
             sum += diff * diff;
@@ -58,7 +61,7 @@ pub trait PointSet {
     }
     #[must_use]
     #[inline]
-    fn try_sq_distance(&self, id: usize, point: &[Self::N]) -> Option<Self::N> {
+    fn try_sq_distance(&self, id: Self::Id, point: &[Self::Value]) -> Option<Self::Value> {
         if !self.exists(id) || point.len() != self.dim().get() {
             return None;
         }
@@ -66,8 +69,8 @@ pub trait PointSet {
     }
     #[must_use]
     #[inline]
-    fn sq_distance_between(&self, id_a: usize, id_b: usize) -> Self::N {
-        let mut sum = <Self::N as ConstZero>::ZERO;
+    fn sq_distance_between(&self, id_a: Self::Id, id_b: Self::Id) -> Self::Value {
+        let mut sum = <Self::Value as ConstZero>::ZERO;
         for d in 0..self.dim().get() {
             let diff = self.coord(id_a, d) - self.coord(id_b, d);
             sum += diff * diff;
@@ -76,7 +79,7 @@ pub trait PointSet {
     }
     #[must_use]
     #[inline]
-    fn try_sq_distance_between(&self, id_a: usize, id_b: usize) -> Option<Self::N> {
+    fn try_sq_distance_between(&self, id_a: Self::Id, id_b: Self::Id) -> Option<Self::Value> {
         if !self.exists(id_a) || !self.exists(id_b) {
             return None;
         }
@@ -84,7 +87,7 @@ pub trait PointSet {
     }
     #[must_use]
     #[inline]
-    fn to_boxed_slice(&self, id: usize) -> Option<Box<[Self::N]>> {
+    fn to_boxed_slice(&self, id: Self::Id) -> Option<Box<[Self::Value]>> {
         self.exists(id)
             .then(|| (0..self.dim().get()).map(|d| self.coord(id, d)).collect())
     }
@@ -93,27 +96,32 @@ impl<P> PointSet for &P
 where
     P: PointSet + ?Sized,
 {
-    type N = P::N;
+    type Id = P::Id;
+    type Value = P::Value;
     #[inline]
     fn size(&self) -> NonZeroUsize { (**self).size() }
     #[inline]
-    fn id_iter(&self) -> impl Iterator<Item = usize> { (**self).id_iter() }
+    fn id_iter(&self) -> impl Iterator<Item = Self::Id> { (**self).id_iter() }
     #[inline]
     fn dim(&self) -> NonZeroUsize { (**self).dim() }
     #[inline]
-    fn exists(&self, id: usize) -> bool { (**self).exists(id) }
+    fn exists(&self, id: Self::Id) -> bool { (**self).exists(id) }
     #[inline]
-    fn coord(&self, id: usize, dim: usize) -> Self::N { (**self).coord(id, dim) }
+    fn coord(&self, id: Self::Id, dim: usize) -> Self::Value { (**self).coord(id, dim) }
     #[inline]
-    fn try_coord(&self, id: usize, dim: usize) -> Option<Self::N> { (**self).try_coord(id, dim) }
+    fn try_coord(&self, id: Self::Id, dim: usize) -> Option<Self::Value> {
+        (**self).try_coord(id, dim)
+    }
     #[inline]
-    fn sq_distance(&self, id: usize, point: &[Self::N]) -> Self::N {
+    fn sq_distance(&self, id: Self::Id, point: &[Self::Value]) -> Self::Value {
         (**self).sq_distance(id, point)
     }
     #[inline]
-    fn try_sq_distance(&self, id: usize, point: &[Self::N]) -> Option<Self::N> {
+    fn try_sq_distance(&self, id: Self::Id, point: &[Self::Value]) -> Option<Self::Value> {
         (**self).try_sq_distance(id, point)
     }
     #[inline]
-    fn to_boxed_slice(&self, id: usize) -> Option<Box<[Self::N]>> { (**self).to_boxed_slice(id) }
+    fn to_boxed_slice(&self, id: Self::Id) -> Option<Box<[Self::Value]>> {
+        (**self).to_boxed_slice(id)
+    }
 }


### PR DESCRIPTION
## envisim_utils
### Changed
- Added `fmt::Debug` as a supertrait of `Number`.
- Changed `PointSet` to be generic over `Id` and `Value`, previously only `Value` (renamed from `N`).
- Changed `FindSplit::split`, `MidpointSlide::new`, `Neighbour`, `WeightedNeighbour`, `WeightCollection` to be generic over `units` or `Id`.
- Changed `TreeSearcher`, `SearchPoint`, `NearestNeighbourSearcher`, `KNearestNeighbourSearcher`, `WeightedSearcher`, `Node`, `Leaf`, `Branch` to be generic over `PointSet`.
- Fixed bug in `Border::from_data`.
