### PR TITLE
(feat) Rename methods in PointSet

### DIFF
--- a/envisim_estimate/src/balance.rs
+++ b/envisim_estimate/src/balance.rs
@@ -39,18 +39,18 @@ where
 {
     let population_size = probabilities.len();
 
-    (0..data.dim().get())
+    (0..data.dimensions().get())
         .map(|j| {
             // Calculate the dimension total for the population
             let pop_sum: f64 = (0..population_size)
-                .map(|i| data.try_coord(i, j))
+                .map(|i| data.get_coord(i, j))
                 .sum::<Option<f64>>()
                 .ok_or(EstimationError::InvalidSample)?;
             // Calculate the dimension HT-estimator
             let sample_sum: f64 = sample
                 .iter()
                 .map(|&i| {
-                    data.try_coord(i, j)
+                    data.get_coord(i, j)
                         .zip(probabilities.get(i))
                         .ok_or(EstimationError::InvalidSample)
                         .and_then(ypi_quotient)

--- a/envisim_estimate/src/nearest_neighbour.rs
+++ b/envisim_estimate/src/nearest_neighbour.rs
@@ -42,7 +42,7 @@ pub fn nearest_neighbour<P>(
 where
     P: PointSet<Id = usize, Value = f64>,
 {
-    let population_size = auxiliaries.size().get();
+    let population_size = auxiliaries.len().get();
     let sample_size = sample.len();
 
     if sample.len() != y_values.len() || !sample.iter().all(|id| (0..population_size).contains(id))

--- a/envisim_estimate/src/spatial_balance.rs
+++ b/envisim_estimate/src/spatial_balance.rs
@@ -68,7 +68,7 @@ where
     let tree = Tree::new(opts, &mut sample.to_vec());
     let mut searcher = NearestNeighbourSearcher::new(data);
 
-    for id in data.id_iter() {
+    for id in data.ids() {
         // Units in voronoi means have already been handled
         if pi_sums.contains_key(&id) {
             continue;
@@ -113,7 +113,7 @@ where
 {
     let data = opts.data();
     let sample_size = sample.len();
-    let data_cols = data.dim().get();
+    let data_cols = data.dimensions().get();
     let mut means =
         FxHashMap::<P::Id, Box<[P::Value]>>::with_capacity_and_hasher(sample_size, FxBuildHasher);
 
@@ -137,7 +137,7 @@ where
     let tree = Tree::new(opts, &mut sample.to_vec());
     let mut searcher = NearestNeighbourSearcher::new(data);
 
-    for id in data.id_iter() {
+    for id in data.ids() {
         // Units in voronoi means have already been handled
         if means.contains_key(&id) {
             continue;
@@ -179,16 +179,16 @@ fn norm_matrix<P>(data: P, balance_probabilities: bool) -> Matrix<P::Value>
 where
     P: PointSet<Value = f64>,
 {
-    let data_cols = data.dim().get();
+    let data_cols = data.dimensions().get();
     let cols = data
-        .dim()
+        .dimensions()
         .saturating_add(usize::from(balance_probabilities));
     let mut norm_matrix = Matrix::from_value(0.0, MatrixDims::new(cols, cols));
 
-    for id in data.id_iter() {
+    for id in data.ids() {
         // Last column as probs column
         if balance_probabilities {
-            norm_matrix[(data.dim().get(), data.dim().get())] += 1.0;
+            norm_matrix[(data.dimensions().get(), data.dimensions().get())] += 1.0;
         }
 
         for i in 0..data_cols {
@@ -218,12 +218,12 @@ fn energy_distance_phi_equal<P>(matrix: &P) -> (FxHashMap<P::Id, P::Value>, P::V
 where
     P: PointSet<Value = f64>,
 {
-    let size = matrix.size().get();
+    let size = matrix.len().get();
     let mut phi = FxHashMap::<P::Id, P::Value>::with_capacity_and_hasher(size, FxBuildHasher);
 
-    for (i, id1) in matrix.id_iter().enumerate() {
+    for (i, id1) in matrix.ids().enumerate() {
         let mut phi1 = <P::Value as ConstZero>::ZERO;
-        for id2 in matrix.id_iter().take(i) {
+        for id2 in matrix.ids().take(i) {
             let dist = matrix.sq_distance_between(id1, id2).sqrt();
             phi1 += dist;
             *phi.get_mut(&id2).expect("id2 to exist in map") += dist;
@@ -253,7 +253,7 @@ where
 {
     let population_size = probabilities.len();
     assert!(
-        population_size <= matrix.size().get(),
+        population_size <= matrix.len().get(),
         "not able to map between prob indices and PointSet"
     );
     let mut phi =
@@ -408,7 +408,7 @@ where
 
         let data = self.spreading().data();
         let cols = data
-            .dim()
+            .dimensions()
             .saturating_add(usize::from(balance_probabilities));
         let p = self.probabilities().as_real();
         let p_factor = (1.0 - p) / p;
@@ -480,7 +480,7 @@ where
 
         let data = self.spreading().data();
         let cols = data
-            .dim()
+            .dimensions()
             .saturating_add(usize::from(balance_probabilities));
         let probs = self.probabilities().to_slice_real();
         let voronoi_means = voronoi_means(

--- a/envisim_samplr/src/dbd/dbd_circular.rs
+++ b/envisim_samplr/src/dbd/dbd_circular.rs
@@ -190,7 +190,7 @@ impl<P> DbdCircular<P> {
     where
         P: PointSet<Id = usize, Value = f64>,
     {
-        let sequence: Vec<usize> = matrix.id_iter().collect();
+        let sequence: Vec<usize> = matrix.ids().collect();
         let annealing_temperature = dbs_options.as_annealing_temperature(eps);
         let ed = EnergyDistance::new(matrix, sample_size);
 

--- a/envisim_samplr/src/dbd/dbd_tc.rs
+++ b/envisim_samplr/src/dbd/dbd_tc.rs
@@ -220,7 +220,7 @@ impl<P> DbdTacticalConfiguration<P> {
         P: PointSet<Id = usize, Value = f64>,
         R: SamplingOptionsRng<EqualProbabilityOptions>,
     {
-        let population_size = matrix.size();
+        let population_size = matrix.len();
         let sample_size = sample_size.min(population_size);
         let tcp = TacticalConfigurationParameters::new_minimal(population_size, sample_size);
 

--- a/envisim_samplr/src/dbd/energy_distance.rs
+++ b/envisim_samplr/src/dbd/energy_distance.rs
@@ -38,13 +38,13 @@ impl<P> EnergyDistance<P> {
     where
         P: PointSet<Id = usize, Value = f64>,
     {
-        let size = matrix.size().get();
+        let size = matrix.len().get();
         let u_size = size.to_f64().expect("matrix size to convert to f64");
         let mut phi = vec![0.0; size];
         let mut u_spread = 0.0;
 
-        for id1 in matrix.id_iter() {
-            for id2 in matrix.id_iter().skip(id1 + 1) {
+        for id1 in matrix.ids() {
+            for id2 in matrix.ids().skip(id1 + 1) {
                 let dist = matrix.sq_distance_between(id1, id2).sqrt();
                 phi[id1] += dist;
                 phi[id2] += dist;

--- a/envisim_utils/CHANGELOG.md
+++ b/envisim_utils/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Renamed methods in `PointSet`. Use prefix `get_` rather than `try_`, renamed `exists` to `contains`, `size` to `len`, `dim` to `dimensions`, `id_iter` to `ids`. Added methods `coords` and `get_coords`, returning an iterator over an id.
+
 
 ## [0.6.0] - 2026-06-02
 ### Changed

--- a/envisim_utils/src/kd_tree/mod.rs
+++ b/envisim_utils/src/kd_tree/mod.rs
@@ -136,7 +136,7 @@ where
     #[must_use]
     #[inline]
     pub fn find_leaf(&self, unit: &[P::Value]) -> Option<&Leaf<P>> {
-        (unit.len() == self.data.dim().get()).then(|| self.node.find_leaf(unit))
+        (unit.len() == self.data.dimensions().get()).then(|| self.node.find_leaf(unit))
     }
     /// Iterates the leaf by a [`TreeSearcher`].
     #[must_use]
@@ -145,7 +145,7 @@ where
     where
         S: TreeSearcher<P>,
     {
-        if self.data.dim().get() == searcher.point().len() {
+        if self.data.dimensions().get() == searcher.point().len() {
             self.node.iterate_leafs_by(self.data, searcher)
         } else {
             None
@@ -165,7 +165,7 @@ where
     #[must_use]
     #[inline]
     pub fn find_leaf_mut(&mut self, unit: &[P::Value]) -> Option<&mut Leaf<P>> {
-        (unit.len() == self.data.dim().get()).then(|| self.node.find_leaf_mut(unit))
+        (unit.len() == self.data.dimensions().get()).then(|| self.node.find_leaf_mut(unit))
     }
     /// Inserts a unit into the tree.
     /// Returns `None` if `unit` does not exists in the tree data.

--- a/envisim_utils/src/kd_tree/searcher.rs
+++ b/envisim_utils/src/kd_tree/searcher.rs
@@ -300,7 +300,7 @@ where
     #[inline]
     pub fn new(data: &P) -> Self {
         Self {
-            point: SearchPoint::new(data.dim()),
+            point: SearchPoint::new(data.dimensions()),
             neighbours: Vec::with_capacity(6),
         }
     }
@@ -422,7 +422,7 @@ where
     #[inline]
     pub fn new(k: NonZeroUsize, data: &P) -> Self {
         Self {
-            point: SearchPoint::new(data.dim()),
+            point: SearchPoint::new(data.dimensions()),
             neighbours: Vec::with_capacity(k.get() + 6),
             nominal_size: k,
         }
@@ -590,7 +590,7 @@ where
     #[inline]
     pub fn new(data: &P) -> Self {
         Self {
-            point: SearchPoint::new(data.dim()),
+            point: SearchPoint::new(data.dimensions()),
             point_weight: 0.5,
             neighbours: Vec::with_capacity(6),
             total_weight: 0.0,

--- a/envisim_utils/src/kd_tree/split_methods.rs
+++ b/envisim_utils/src/kd_tree/split_methods.rs
@@ -372,7 +372,7 @@ impl<N> MidpointSlide<N> {
         P: PointSet<Value = N>,
     {
         Self {
-            borders: (0..data.dim().get())
+            borders: (0..data.dimensions().get())
                 .map(|d| Border::from_data(data, units, d))
                 .collect(),
         }
@@ -424,7 +424,7 @@ impl<N> MidpointSlide<N> {
         P: PointSet<Value = N>,
     {
         assert_eq!(
-            data.dim().get(),
+            data.dimensions().get(),
             self.borders.len(),
             "data dimensions must match the size of the number of borders in the split"
         );

--- a/envisim_utils/src/matrix/mod.rs
+++ b/envisim_utils/src/matrix/mod.rs
@@ -590,17 +590,17 @@ where
     type Id = usize;
     /// Returns the number of rows in the matrix
     #[inline]
-    fn size(&self) -> NonZeroUsize { self.dims.rows }
+    fn len(&self) -> NonZeroUsize { self.dims.rows }
     /// Returns an iterator of the rows in the matrix.
     #[inline]
-    fn id_iter(&self) -> impl Iterator<Item = usize> { 0..self.dims.rows.get() }
+    fn ids(&self) -> impl Iterator<Item = usize> { 0..self.dims.rows.get() }
     /// Returns the number of columns in the matrix
     #[inline]
-    fn dim(&self) -> NonZeroUsize { self.dims.cols }
+    fn dimensions(&self) -> NonZeroUsize { self.dims.cols }
     /// Returns true if `id` is contained within the matrix.
     #[expect(clippy::renamed_function_params, reason = "a matrix has rows, not ids")]
     #[inline]
-    fn exists(&self, row: usize) -> bool { row < self.dims.rows.get() }
+    fn contains(&self, row: usize) -> bool { row < self.dims.rows.get() }
     /// Returns the element at coordinates `(row, col)`.
     /// Panics on oob.
     #[expect(clippy::renamed_function_params, reason = "a matrix has rows, not ids")]
@@ -613,7 +613,14 @@ where
     /// Returns `None` if the coordinates are oob.
     #[expect(clippy::renamed_function_params, reason = "a matrix has rows, not ids")]
     #[inline]
-    fn try_coord(&self, row: usize, col: usize) -> Option<N> { self.get((row, col)).copied() }
+    fn get_coord(&self, row: usize, col: usize) -> Option<N> { self.get((row, col)).copied() }
+    /// Returns an iterator over the coords of `row`, or `None` if `row` does not exist.
+    #[expect(clippy::renamed_function_params, reason = "a matrix has rows, not ids")]
+    #[must_use]
+    #[inline]
+    fn get_coords(&self, row: usize) -> Option<impl ExactSizeIterator<Item = &N>> {
+        self.row_iter(row)
+    }
     /// Returns the squared euclidean distance between rows `id_a` and `id_b`.
     /// Panics on oob.
     #[inline]
@@ -634,8 +641,8 @@ where
     /// Returns the squared euclidean distance between rows `id_a` and `id_b`.
     /// Returns `None` if any row is oob.
     #[inline]
-    fn try_sq_distance_between(&self, id_a: usize, id_b: usize) -> Option<N> {
-        (self.exists(id_a) && self.exists(id_b)).then(|| self.sq_distance_between(id_a, id_b))
+    fn get_sq_distance_between(&self, id_a: usize, id_b: usize) -> Option<N> {
+        (self.contains(id_a) && self.contains(id_b)).then(|| self.sq_distance_between(id_a, id_b))
     }
 }
 
@@ -735,15 +742,15 @@ mod tests {
         let m = setup_matrix();
 
         // Basic trait methods
-        assert_eq!(PointSet::size(&m), nz(3));
-        assert_eq!(PointSet::dim(&m), nz(2));
-        assert!(m.exists(2));
-        assert!(!m.exists(3));
+        assert_eq!(PointSet::len(&m), nz(3));
+        assert_eq!(PointSet::dimensions(&m), nz(2));
+        assert!(m.contains(2));
+        assert!(!m.contains(3));
 
         // Coordinate access
         assert_eq!(m.coord(1, 1), 5.0);
-        assert_eq!(m.try_coord(2, 0), Some(3.0));
-        assert_eq!(m.try_coord(3, 0), None);
+        assert_eq!(m.get_coord(2, 0), Some(3.0));
+        assert_eq!(m.get_coord(3, 0), None);
     }
 
     #[test]
@@ -760,7 +767,7 @@ mod tests {
         let same_dist = m.sq_distance_between(2, 2);
         assert_eq!(same_dist, 0.0);
 
-        assert!(m.try_sq_distance_between(0, 3).is_none());
+        assert!(m.get_sq_distance_between(0, 3).is_none());
     }
 
     #[test]

--- a/envisim_utils/src/sampling_options/mod.rs
+++ b/envisim_utils/src/sampling_options/mod.rs
@@ -166,7 +166,7 @@ where
         I: Into<SpreadingOptions<AUXP>>,
     {
         let data = data.into();
-        if data.data().size() != self.population_size() {
+        if data.data().len() != self.population_size() {
             return Err(SamplingOptionsError::InvalidSpreading);
         }
         Ok(SamplingOptions {

--- a/envisim_utils/src/sampling_options/spreading_opts.rs
+++ b/envisim_utils/src/sampling_options/spreading_opts.rs
@@ -45,7 +45,7 @@ impl<P> SpreadingOptions<P> {
         P: PointSet,
     {
         Self {
-            bucket_size: Self::estimate_bucket_size(data.size()),
+            bucket_size: Self::estimate_bucket_size(data.len()),
             data,
         }
     }
@@ -84,7 +84,7 @@ impl<P> SpreadingOptions<P> {
     where
         P: PointSet,
     {
-        let mut units: Vec<P::Id> = self.data.id_iter().collect();
+        let mut units: Vec<P::Id> = self.data.ids().collect();
         Tree::new(self, &mut units)
     }
 }

--- a/envisim_utils/src/spatial.rs
+++ b/envisim_utils/src/spatial.rs
@@ -26,30 +26,41 @@ pub trait PointSet {
 
     /// Number of points in set
     #[must_use]
-    fn size(&self) -> NonZeroUsize;
+    fn len(&self) -> NonZeroUsize;
     /// Iterator over point ids
     #[must_use]
-    fn id_iter(&self) -> impl Iterator<Item = Self::Id>;
+    fn ids(&self) -> impl Iterator<Item = Self::Id>;
     /// Dimensions of point
     #[must_use]
-    fn dim(&self) -> NonZeroUsize;
+    fn dimensions(&self) -> NonZeroUsize;
     /// Returns true of point id exists
     #[must_use]
-    fn exists(&self, id: Self::Id) -> bool;
+    fn contains(&self, id: Self::Id) -> bool;
     /// Returns the dimension value of point `id`
     #[must_use]
     #[inline]
     fn coord(&self, id: Self::Id, dim: usize) -> Self::Value {
-        self.try_coord(id, dim).expect("valid id and dim")
+        self.get_coord(id, dim).expect("valid id and dim")
     }
+    /// Returns the dimension value of point `id`, or `None` if `id` does not exist.
     #[must_use]
-    fn try_coord(&self, id: Self::Id, dim: usize) -> Option<Self::Value>;
+    fn get_coord(&self, id: Self::Id, dim: usize) -> Option<Self::Value>;
+    /// Returns an iterator over the coords of `id`.
+    #[must_use]
+    #[inline]
+    fn coords(&self, id: Self::Id) -> impl ExactSizeIterator<Item = &Self::Value> {
+        self.get_coords(id).expect("valid id")
+    }
+    /// Returns an iterator over the coords of `id`, or `None` if `id` does not exist.
+    #[must_use]
+    fn get_coords(&self, id: Self::Id) -> Option<impl ExactSizeIterator<Item = &Self::Value>>;
+    /// Returns the squared distance between `id` and `point`.
     #[must_use]
     #[inline]
     fn sq_distance(&self, id: Self::Id, point: &[Self::Value]) -> Self::Value {
         assert_eq!(
             point.len(),
-            self.dim().get(),
+            self.dimensions().get(),
             "point dimensions must match set dimension"
         );
         let mut sum = <Self::Value as ConstZero>::ZERO;
@@ -59,37 +70,46 @@ pub trait PointSet {
         }
         sum
     }
+    /// Returns the squared distance between `id` and `point`, or `None` if `id` does not exist or
+    /// `point` does not match the collections dimensions.
     #[must_use]
     #[inline]
-    fn try_sq_distance(&self, id: Self::Id, point: &[Self::Value]) -> Option<Self::Value> {
-        if !self.exists(id) || point.len() != self.dim().get() {
+    fn get_sq_distance(&self, id: Self::Id, point: &[Self::Value]) -> Option<Self::Value> {
+        if !self.contains(id) || point.len() != self.dimensions().get() {
             return None;
         }
         self.sq_distance(id, point).into()
     }
+    /// Returns the squared distance between `id_a` and `id_b`.
     #[must_use]
     #[inline]
     fn sq_distance_between(&self, id_a: Self::Id, id_b: Self::Id) -> Self::Value {
         let mut sum = <Self::Value as ConstZero>::ZERO;
-        for d in 0..self.dim().get() {
+        for d in 0..self.dimensions().get() {
             let diff = self.coord(id_a, d) - self.coord(id_b, d);
             sum += diff * diff;
         }
         sum
     }
+    /// Returns the squared distance between `id_a` and `id_b`, or `None` if `id_a` or `id_b` does
+    /// not exist.
     #[must_use]
     #[inline]
-    fn try_sq_distance_between(&self, id_a: Self::Id, id_b: Self::Id) -> Option<Self::Value> {
-        if !self.exists(id_a) || !self.exists(id_b) {
+    fn get_sq_distance_between(&self, id_a: Self::Id, id_b: Self::Id) -> Option<Self::Value> {
+        if !self.contains(id_a) || !self.contains(id_b) {
             return None;
         }
         self.sq_distance_between(id_a, id_b).into()
     }
+    /// Returns `id` as a boxed slice.
     #[must_use]
     #[inline]
     fn to_boxed_slice(&self, id: Self::Id) -> Option<Box<[Self::Value]>> {
-        self.exists(id)
-            .then(|| (0..self.dim().get()).map(|d| self.coord(id, d)).collect())
+        self.contains(id).then(|| {
+            (0..self.dimensions().get())
+                .map(|d| self.coord(id, d))
+                .collect()
+        })
     }
 }
 impl<P> PointSet for &P
@@ -99,26 +119,34 @@ where
     type Id = P::Id;
     type Value = P::Value;
     #[inline]
-    fn size(&self) -> NonZeroUsize { (**self).size() }
+    fn len(&self) -> NonZeroUsize { (**self).len() }
     #[inline]
-    fn id_iter(&self) -> impl Iterator<Item = Self::Id> { (**self).id_iter() }
+    fn ids(&self) -> impl Iterator<Item = Self::Id> { (**self).ids() }
     #[inline]
-    fn dim(&self) -> NonZeroUsize { (**self).dim() }
+    fn dimensions(&self) -> NonZeroUsize { (**self).dimensions() }
     #[inline]
-    fn exists(&self, id: Self::Id) -> bool { (**self).exists(id) }
+    fn contains(&self, id: Self::Id) -> bool { (**self).contains(id) }
     #[inline]
     fn coord(&self, id: Self::Id, dim: usize) -> Self::Value { (**self).coord(id, dim) }
     #[inline]
-    fn try_coord(&self, id: Self::Id, dim: usize) -> Option<Self::Value> {
-        (**self).try_coord(id, dim)
+    fn get_coord(&self, id: Self::Id, dim: usize) -> Option<Self::Value> {
+        (**self).get_coord(id, dim)
+    }
+    #[inline]
+    fn coords(&self, id: Self::Id) -> impl ExactSizeIterator<Item = &Self::Value> {
+        (**self).coords(id)
+    }
+    #[inline]
+    fn get_coords(&self, id: Self::Id) -> Option<impl ExactSizeIterator<Item = &Self::Value>> {
+        (**self).get_coords(id)
     }
     #[inline]
     fn sq_distance(&self, id: Self::Id, point: &[Self::Value]) -> Self::Value {
         (**self).sq_distance(id, point)
     }
     #[inline]
-    fn try_sq_distance(&self, id: Self::Id, point: &[Self::Value]) -> Option<Self::Value> {
-        (**self).try_sq_distance(id, point)
+    fn get_sq_distance(&self, id: Self::Id, point: &[Self::Value]) -> Option<Self::Value> {
+        (**self).get_sq_distance(id, point)
     }
     #[inline]
     fn to_boxed_slice(&self, id: Self::Id) -> Option<Box<[Self::Value]>> {

--- a/envisim_utils/src/spatial.rs
+++ b/envisim_utils/src/spatial.rs
@@ -20,6 +20,9 @@ use num_traits::ConstZero;
 
 use crate::number_traits::Number;
 
+/// Methods for accessing containers of points in some coordinate system.
+/// The container must not be empty.
+#[expect(clippy::len_without_is_empty, reason = "cannot be empty")]
 pub trait PointSet {
     type Id: Sized + Eq + Hash + Ord + Copy + Debug;
     type Value: Number;


### PR DESCRIPTION
## envisim_utils
### Changed
- Renamed methods in `PointSet`. Use prefix `get_` rather than `try_`, renamed `exists` to `contains`, `size` to `len`, `dim` to `dimensions`, `id_iter` to `ids`. Added methods `coords` and `get_coords`, returning an iterator over an id.