### PR TITLE
(feat) Remove intermediate storage for Matrix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,9 @@ members = [
   "envisim_utils",
   "envisim_estimate",
   "envisim_samplr",
-  "rsamplr_pkg/src/rust",
+]
+exclude = [
+  "rsamplr_pkg/src/rust", # cannot be part of workspace, as it needs own lockfile
 ]
 
 [workspace.lints.clippy]

--- a/envisim_utils/CHANGELOG.md
+++ b/envisim_utils/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Methods `SamplingOptions::with_spreading` and `with_balancing` for equal probability sampling, setting the population size from the provided data.
+
 ### Changed
 - Renamed methods in `PointSet`. Use prefix `get_` rather than `try_`, renamed `exists` to `contains`, `size` to `len`, `dim` to `dimensions`, `id_iter` to `ids`. Added methods `coords` and `get_coords`, returning an iterator over an id.
 - For searchers in `kd_tree::searcher`, renamed `from_slice`, `set_from_slice`, `reset_from_slice` to `_point`. These methods now accepts iterators instead of slices.

--- a/envisim_utils/CHANGELOG.md
+++ b/envisim_utils/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Renamed methods in `PointSet`. Use prefix `get_` rather than `try_`, renamed `exists` to `contains`, `size` to `len`, `dim` to `dimensions`, `id_iter` to `ids`. Added methods `coords` and `get_coords`, returning an iterator over an id.
 - For searchers in `kd_tree::searcher`, renamed `from_slice`, `set_from_slice`, `reset_from_slice` to `_point`. These methods now accepts iterators instead of slices.
+- Matrix storage: Removed `OwnedMatrixData`, `BorrowedMatrixData` and added `RawDataMut`. Implemented `RawData` and `RawDataMut` for array-like types in `std`.
 
+### Removed
+- Removed second (ergonomic) generic for data type in `Matrix`. Defaulted to `RawData::Elem`, now derived from the same.
 
 ## [0.6.0] - 2026-06-02
 ### Changed

--- a/envisim_utils/Cargo.toml
+++ b/envisim_utils/Cargo.toml
@@ -20,7 +20,7 @@ workspace = true
 num-integer = "0.1.46"
 num-traits = "0.2.19"
 rand_core = {version="0.10.1"}
-rand = {version="0.10.1", optional = true}
+rand = {version="0.10.1", optional=true, default-features=false, features=["sys_rng"]}
 rustc-hash = "2.1.1"
 
 [features]

--- a/envisim_utils/src/matrix/mod.rs
+++ b/envisim_utils/src/matrix/mod.rs
@@ -29,11 +29,14 @@ pub use dims::{
     MatrixCoord,
     MatrixDims,
 };
-use num_traits::Float;
+use num_traits::{
+    ConstOne,
+    ConstZero,
+    Float,
+};
 pub use raw_data::{
-    BorrowedMatrixData,
-    OwnedMatrixData,
     RawData,
+    RawDataMut,
 };
 
 use crate::number_traits::{
@@ -46,10 +49,7 @@ pub use crate::spatial::PointSet;
 /// Base matrix representation
 #[must_use]
 #[derive(Debug, Clone)]
-pub struct MatrixBase<T, N = <T as RawData>::Elem>
-where
-    T: RawData<Elem = N>,
-{
+pub struct MatrixBase<T> {
     /// Data
     data: T,
     /// Matrix dimension
@@ -57,30 +57,43 @@ where
 }
 
 /// Owned matrix representation
-pub type Matrix<N> = MatrixBase<OwnedMatrixData<N>>;
+pub type Matrix<N> = MatrixBase<Vec<N>>;
 /// Borrowed matrix representation
-pub type MatrixRef<'bdata, N> = MatrixBase<BorrowedMatrixData<'bdata, N>>;
+pub type MatrixRef<'bdata, N> = MatrixBase<&'bdata [N]>;
 
-impl<T, N> MatrixBase<T, N>
-where
-    T: RawData<Elem = N>,
-{
+impl<T> MatrixBase<T> {
+    /// Constructs a new owned matrix representation from some data vector.
+    /// Returns `None` if the rows are not a divisor of the data length.
+    #[inline]
+    pub fn new<NZ>(data: T, rows: NZ) -> Option<Self>
+    where
+        T: RawData,
+        NZ: TryInto<NonZeroUsize>,
+    {
+        let rows = rows.try_into().ok()?;
+        let dims = MatrixDims::from_row_count(data.data().len(), rows)?;
+        Some(Self { data, dims })
+    }
     /// Constructs a borrowed matrix representation from a matrix.
     #[inline]
-    pub fn to_matrixref(&self) -> MatrixRef<'_, N> {
+    pub fn to_matrixref(&self) -> MatrixRef<'_, T::Elem>
+    where
+        T: RawData,
+    {
         MatrixRef {
-            data: self.internal_data().into(),
+            data: self.data.data(),
             dims: self.dims(),
         }
     }
     /// Constructs an owned matrix representation from a matrix. Copies the data.
     #[inline]
-    pub fn to_matrix(&self) -> Matrix<N>
+    pub fn to_matrix(&self) -> Matrix<T::Elem>
     where
-        N: Copy,
+        T: RawData,
+        T::Elem: Copy,
     {
         Matrix {
-            data: self.internal_data().to_vec().into(),
+            data: self.data.data().to_vec(),
             dims: self.dims(),
         }
     }
@@ -88,60 +101,108 @@ where
     #[must_use]
     #[inline]
     pub fn data(&self) -> &T { &self.data }
-    /// Returns a reference to the underlying data as a slice.
-    #[must_use]
-    #[inline]
-    fn internal_data(&self) -> &[N] { self.data().data() }
     /// Returns the element at a specific coordinate.
     /// Returns `None`  if the coordinates are invalid.
     #[must_use]
     #[inline]
-    pub fn get<C>(&self, coord: C) -> Option<&N>
+    pub fn get<C>(&self, coord: C) -> Option<&T::Elem>
     where
+        T: RawData,
         C: Into<MatrixCoord>,
-        N: Copy,
     {
         let coord = coord.into();
         self.dims.contains(coord).then(|| &self[coord])
+    }
+    /// Returns a mutable reference to the element at a specific coordinate.
+    /// Returns `None`  if the coordinates are invalid.
+    #[must_use]
+    #[inline]
+    pub fn get_mut<C>(&mut self, coord: C) -> Option<&mut T::Elem>
+    where
+        T: RawDataMut,
+        C: Into<MatrixCoord>,
+    {
+        let coord = coord.into();
+        self.dims.contains(coord).then(|| &mut self[coord])
     }
     /// Returns an iterator of the elements in a row.
     /// Returns `None` if the row is invalid.
     #[must_use]
     #[inline]
-    pub fn row_iter(&self, row: usize) -> Option<impl ExactSizeIterator<Item = &N>> {
+    pub fn row_iter(&self, row: usize) -> Option<impl ExactSizeIterator<Item = &T::Elem>>
+    where
+        T: RawData,
+    {
         let nrow = self.nrow().get();
         self.dims()
             .contains_row(row)
-            .then(|| self.internal_data()[row..].iter().step_by(nrow))
+            .then(|| self.data.data()[row..].iter().step_by(nrow))
+    }
+    /// Returns a mutable iterator of the elements in a row.
+    /// Returns `None` if the row is invalid.
+    #[must_use]
+    #[inline]
+    pub fn row_iter_mut(
+        &mut self,
+        row: usize,
+    ) -> Option<impl ExactSizeIterator<Item = &mut T::Elem>>
+    where
+        T: RawDataMut,
+    {
+        let nrow = self.nrow().get();
+        self.dims()
+            .contains_row(row)
+            .then(|| self.data.data_mut()[row..].iter_mut().step_by(nrow))
     }
     /// Returns an iterator of the elements in a column.
     /// Returns `None` if the column is invalid.
     #[must_use]
     #[inline]
-    pub fn col_iter(&self, col: usize) -> Option<impl ExactSizeIterator<Item = &N>> {
+    pub fn col_iter(&self, col: usize) -> Option<impl ExactSizeIterator<Item = &T::Elem>>
+    where
+        T: RawData,
+    {
         let nrow = self.nrow().get();
         let start = nrow * col;
         self.dims()
             .contains_col(col)
-            .then(|| self.internal_data()[start..(start + nrow)].iter())
+            .then(|| self.data.data()[start..(start + nrow)].iter())
+    }
+    /// Returns a mutable iterator of the elements in a column.
+    /// Returns `None` if the column is invalid.
+    #[must_use]
+    #[inline]
+    pub fn col_iter_mut(
+        &mut self,
+        col: usize,
+    ) -> Option<impl ExactSizeIterator<Item = &mut T::Elem>>
+    where
+        T: RawDataMut,
+    {
+        let nrow = self.nrow().get();
+        let start = nrow * col;
+        self.dims()
+            .contains_col(col)
+            .then(|| self.data.data_mut()[start..(start + nrow)].iter_mut())
     }
     /// Multiplies the matrix by a column vector.
     /// Returns `None` if the column vector length does not match the number of columns in the
     /// matrix.
     #[must_use]
     #[inline]
-    pub fn mul_vec(&self, rhs: &[N]) -> Option<Matrix<N>>
+    pub fn mul_vec(&self, rhs: &[T::Elem]) -> Option<Matrix<T::Elem>>
     where
-        N: Number,
+        T: RawData,
+        T::Elem: Number,
     {
         if self.ncol().get() != rhs.len() {
             return None;
         }
-        let mut product = vec![N::zero(); self.nrow().get()];
+        let mut product = vec![T::Elem::ZERO; self.nrow().get()];
         let mut index = 0;
         for mul in rhs {
             for pr in &mut product {
-                *pr += *mul * self.internal_data()[index];
+                *pr += *mul * self.data.data()[index];
                 index += 1;
             }
         }
@@ -152,126 +213,135 @@ where
     /// other matrix.
     #[must_use]
     #[inline]
-    pub fn mul_mat<T2>(&self, rhs: &MatrixBase<T2, N>) -> Option<Matrix<N>>
+    pub fn mul_mat<T2>(&self, rhs: &MatrixBase<T2>) -> Option<Matrix<T::Elem>>
     where
-        T2: RawData<Elem = N>,
-        N: Number,
+        T: RawData,
+        T::Elem: Number,
+        T2: RawData<Elem = T::Elem>,
     {
         if self.ncol() != rhs.nrow() {
             return None;
         }
-        let mut product = Vec::<N>::with_capacity(self.nrow().get() * rhs.ncol().get());
+        let mut product = Vec::<T::Elem>::with_capacity(self.nrow().get() * rhs.ncol().get());
         let mut index = 0;
         // Multiply self by each column in rhs
         for _ in 0..rhs.ncol().get() {
             // Take rhs column
-            let rhs_col = &rhs.internal_data()[index..(index + rhs.nrow().get())];
+            let rhs_col = &rhs.data.data()[index..(index + rhs.nrow().get())];
             // Result
             let temp_column_res = self.mul_vec(rhs_col)?;
-            product.extend_from_slice(temp_column_res.internal_data());
+            product.extend_from_slice(temp_column_res.data.data());
             index += rhs.nrow().get();
         }
         Matrix::new(product, self.nrow())
     }
-}
+    /// Calculates the inverse of `self` using LU decomposition.
+    ///
+    /// Returns `None` if `self` isn't square, or if `self` is not invertible (as defined by `eps`).
+    #[expect(clippy::many_single_char_names, reason = "only within small scope")]
+    #[must_use]
+    #[inline]
+    pub fn inverse<E>(&self, eps: E) -> Option<Matrix<T::Elem>>
+    where
+        T: RawData,
+        T::Elem: NumberFloat,
+        E: TryInto<Epsilon<T::Elem>>,
+    {
+        // Non-square
+        if !self.dims().is_square() {
+            return None;
+        }
+        let eps = eps.try_into().ok()?;
+        let nrow = self.nrow().get();
 
-impl<N> Matrix<N> {
-    /// Constructs a new owned matrix representation from some data vector.
-    /// Returns `None` if the rows are not a divisor of the data length.
-    #[inline]
-    pub fn new<NZ>(data: Vec<N>, rows: NZ) -> Option<Self>
-    where
-        NZ: TryInto<NonZeroUsize>,
-    {
-        let rows = rows.try_into().ok()?;
-        let dims = MatrixDims::from_row_count(data.len(), rows)?;
-        let data = OwnedMatrixData::new(data);
-        Some(Self { data, dims })
-    }
-    /// Constructs a new owned matrix representation filled with some value `data`.
-    #[inline]
-    pub fn from_value<D>(data: N, dims: D) -> Self
-    where
-        N: Copy,
-        D: Into<MatrixDims>,
-    {
-        let dims: MatrixDims = dims.into();
-        Self {
-            data: OwnedMatrixData::new(vec![data; dims.len().get()]),
-            dims,
+        if nrow == 2 {
+            const NZ2: NonZeroUsize = NonZeroUsize::new(2).expect("2 > 0");
+            // ab cd => 02 13
+            #[expect(clippy::unreachable, reason = "panic implies bug")]
+            let &[a, c, b, d] = self.data.data() else {
+                unreachable!("2x2 = 4")
+            };
+            // ad-bc
+            let det = a * d - b * c;
+            if eps.is_zero(det) {
+                return None;
+            };
+            // d -c -b a
+            let inv = vec![d / det, -c / det, -b / det, a / det];
+            return MatrixBase::new(inv, NZ2);
+        } else if nrow == 3 {
+            const NZ3: NonZeroUsize = NonZeroUsize::new(3).expect("3 > 0");
+            // abc def ghi => 036 147 258
+            #[expect(clippy::unreachable, reason = "panic implies bug")]
+            let &[a, d, g, b, e, h, c, f, i] = self.data.data() else {
+                unreachable!("3x3=9")
+            };
+            let mut inv = vec![
+                e * i - f * h,
+                -(d * i - f * g),
+                d * h - e * g, // ABC
+                -(b * i - c * h),
+                a * i - c * g,
+                -(a * h - b * g), // DEF
+                b * f - c * e,
+                -(a * f - c * d),
+                a * e - b * d, // GHI
+            ];
+            let det = a * inv[0] + b * inv[1] + c * inv[2]; // aA + bB +cC
+            if eps.is_zero(det) {
+                return None;
+            };
+            for v in &mut inv {
+                *v /= det;
+            }
+            return MatrixBase::new(inv, NZ3);
         }
-    }
-    /// Constructs a new identity matrix
-    #[inline]
-    pub fn new_identity<NZ>(rows: NZ) -> Option<Self>
-    where
-        N: Number,
-        NZ: TryInto<NonZeroUsize>,
-    {
-        let rows = rows.try_into().ok()?;
-        let dims = MatrixDims::new(rows, rows);
-        let mut m = Self::from_value(N::ZERO, dims);
-        for r in 0..rows.get() {
-            m[(r, r)] = N::ONE;
+
+        let (lu, p) = {
+            let mut lu = self.to_matrix();
+            let p = lu.lu_decomposition(eps)?;
+            (lu, p)
+        };
+
+        let mut inv = MatrixBase::from_value(T::Elem::ZERO, self.dims());
+
+        // Solve for each column of the identity mat
+        for col in 0..nrow {
+            // Solve LY = P
+            for row in 0..nrow {
+                let mut sum = if p[row] == col {
+                    T::Elem::ONE
+                } else {
+                    T::Elem::ZERO
+                };
+                for k in 0..row {
+                    sum -= lu[(row, k)] * inv[(k, col)];
+                }
+                inv[(row, col)] = sum;
+            }
+
+            // Solve UX =  Y for X
+            for row in (0..nrow).rev() {
+                let mut sum = inv[(row, col)];
+                for k in (row + 1)..nrow {
+                    sum -= lu[(row, k)] * inv[(k, col)];
+                }
+                inv[(row, col)] = sum / lu[(row, row)];
+            }
         }
-        Some(m)
-    }
-    /// Returns a mutable reference to the element at a specific coordinate.
-    /// Returns `None`  if the coordinates are invalid.
-    #[must_use]
-    #[inline]
-    pub fn get_mut<C>(&mut self, coord: C) -> Option<&mut N>
-    where
-        C: Into<MatrixCoord>,
-    {
-        let coord = coord.into();
-        self.dims.contains(coord).then(|| &mut self[coord])
-    }
-    /// Returns a mutable iterator of the elements in a row.
-    /// Returns `None` if the row is invalid.
-    #[must_use]
-    #[inline]
-    pub fn row_iter_mut(&mut self, row: usize) -> Option<impl ExactSizeIterator<Item = &mut N>> {
-        let nrow = self.nrow().get();
-        self.dims()
-            .contains_row(row)
-            .then(|| self.data.data[row..].iter_mut().step_by(nrow))
-    }
-    /// Returns a mutable iterator of the elements in a column.
-    /// Returns `None` if the column is invalid.
-    #[must_use]
-    #[inline]
-    pub fn col_iter_mut(&mut self, col: usize) -> Option<impl ExactSizeIterator<Item = &mut N>> {
-        let nrow = self.nrow().get();
-        let start = nrow * col;
-        self.dims()
-            .contains_col(col)
-            .then(|| self.data.data[start..(start + nrow)].iter_mut())
-    }
-    /// Resizes the matrix.
-    /// Does not respect data on expansion.
-    #[inline]
-    pub fn resize<D>(&mut self, dims: D)
-    where
-        N: Copy + num_traits::Zero,
-        D: Into<MatrixDims>,
-    {
-        let dims: MatrixDims = dims.into();
-        if dims == self.dims() {
-            return;
-        }
-        self.data.data.resize(dims.len().get(), N::zero());
-        self.dims = dims;
+
+        Some(inv)
     }
     /// Calculates the reduced row echelon form of the matrix, in place.
     #[inline]
     pub fn reduced_row_echelon_form(&mut self)
     where
-        N: NumberFloat,
+        T: RawDataMut,
+        T::Elem: NumberFloat,
     {
         let dims = self.dims();
         let index = |row, col| row + col * dims.rows.get();
-        let data = &mut self.data.data;
+        let data = self.data.data_mut();
 
         let mut lead: usize = 0;
 
@@ -284,7 +354,7 @@ impl<N> Matrix<N> {
 
             let mut i: usize = row;
 
-            while data[index(i, lead)] == N::zero() {
+            while data[index(i, lead)] == T::Elem::ZERO {
                 i += 1;
 
                 if i == dims.rows.get() {
@@ -312,8 +382,8 @@ impl<N> Matrix<N> {
             {
                 let mut index_row = index(row, lead);
                 let lead_value = data[index_row];
-                if lead_value != N::one() {
-                    data[index_row] = N::one();
+                if lead_value != T::Elem::ONE {
+                    data[index_row] = T::Elem::ONE;
                     index_row += dims.rows.get();
 
                     for _ in (lead + 1)..dims.cols.get() {
@@ -332,11 +402,11 @@ impl<N> Matrix<N> {
                 let mut index_j = index(j, lead);
 
                 let lead_multiplicator = data[index_j];
-                if lead_multiplicator == N::zero() {
+                if lead_multiplicator == T::Elem::ZERO {
                     continue;
                 }
 
-                data[index_j] = N::zero();
+                data[index_j] = T::Elem::ZERO;
                 index_j += dims.rows.get();
                 let mut index_row = index(row, lead + 1);
 
@@ -363,8 +433,9 @@ impl<N> Matrix<N> {
     #[inline]
     pub fn lu_decomposition<E>(&mut self, eps: E) -> Option<Box<[usize]>>
     where
-        N: NumberFloat,
-        E: TryInto<Epsilon<N>>,
+        T: RawDataMut,
+        T::Elem: NumberFloat,
+        E: TryInto<Epsilon<T::Elem>>,
     {
         // Non-square
         if !self.dims().is_square() {
@@ -377,7 +448,7 @@ impl<N> Matrix<N> {
         for row in 0..nrows {
             // Find pivot_row, the row with the highest value in the row-column
             let mut pivot_row = row;
-            let mut max_val = N::ZERO;
+            let mut max_val = T::Elem::ZERO;
             for row_b in row..nrows {
                 let val = Float::abs(self[(row_b, row)]);
                 if !Float::is_finite(val) {
@@ -402,7 +473,7 @@ impl<N> Matrix<N> {
                     // guaranteed: row < pivot_row
                     let index_r = MatrixCoord::new(row, col).to_linear_unchecked(self.dims());
                     let index_p = index_r + (pivot_row - row);
-                    self.data.data.swap(index_r, index_p);
+                    self.data.data_mut().swap(index_r, index_p);
                 }
             }
 
@@ -423,125 +494,63 @@ impl<N> Matrix<N> {
 
         Some(p)
     }
-    /// Calculates the inverse of `self` using LU decomposition.
-    ///
-    /// Returns `None` if `self` isn't square, or if `self` is not invertible (as defined by `eps`).
-    #[expect(clippy::many_single_char_names, reason = "only within small scope")]
-    #[must_use]
-    #[inline]
-    pub fn inverse<E>(&self, eps: E) -> Option<Self>
-    where
-        N: NumberFloat,
-        E: TryInto<Epsilon<N>>,
-    {
-        // Non-square
-        if !self.dims().is_square() {
-            return None;
-        }
-        let eps = eps.try_into().ok()?;
-        let nrow = self.nrow().get();
-
-        if nrow == 2 {
-            const NZ2: NonZeroUsize = NonZeroUsize::new(2).expect("2 > 0");
-            // ab cd => 02 13
-            #[expect(clippy::unreachable, reason = "panic implies bug")]
-            let &[a, c, b, d] = self.internal_data() else {
-                unreachable!("2x2 = 4")
-            };
-            // ad-bc
-            let det = a * d - b * c;
-            if eps.is_zero(det) {
-                return None;
-            };
-            // d -c -b a
-            let inv = vec![d / det, -c / det, -b / det, a / det];
-            return Self::new(inv, NZ2);
-        } else if nrow == 3 {
-            const NZ3: NonZeroUsize = NonZeroUsize::new(3).expect("3 > 0");
-            // abc def ghi => 036 147 258
-            #[expect(clippy::unreachable, reason = "panic implies bug")]
-            let &[a, d, g, b, e, h, c, f, i] = self.internal_data() else {
-                unreachable!("3x3=9")
-            };
-            let mut inv = vec![
-                e * i - f * h,
-                -(d * i - f * g),
-                d * h - e * g, // ABC
-                -(b * i - c * h),
-                a * i - c * g,
-                -(a * h - b * g), // DEF
-                b * f - c * e,
-                -(a * f - c * d),
-                a * e - b * d, // GHI
-            ];
-            let det = a * inv[0] + b * inv[1] + c * inv[2]; // aA + bB +cC
-            if eps.is_zero(det) {
-                return None;
-            };
-            for v in &mut inv {
-                *v /= det;
-            }
-            return Self::new(inv, NZ3);
-        }
-
-        let (lu, p) = {
-            let mut lu = self.clone();
-            let p = lu.lu_decomposition(eps)?;
-            (lu, p)
-        };
-
-        let mut inv = Self::from_value(N::ZERO, self.dims());
-
-        // Solve for each column of the identity mat
-        for col in 0..nrow {
-            // Solve LY = P
-            for row in 0..nrow {
-                let mut sum = if p[row] == col { N::ONE } else { N::ZERO };
-                for k in 0..row {
-                    sum -= lu[(row, k)] * inv[(k, col)];
-                }
-                inv[(row, col)] = sum;
-            }
-
-            // Solve UX =  Y for X
-            for row in (0..nrow).rev() {
-                let mut sum = inv[(row, col)];
-                for k in (row + 1)..nrow {
-                    sum -= lu[(row, k)] * inv[(k, col)];
-                }
-                inv[(row, col)] = sum / lu[(row, row)];
-            }
-        }
-
-        Some(inv)
-    }
 }
 
-impl<'bdata, N> MatrixRef<'bdata, N> {
+impl<N> Matrix<N> {
+    /// Constructs a new owned matrix representation filled with some value `data`.
     #[inline]
-    pub fn new<NZ>(data: &'bdata [N], rows: NZ) -> Option<Self>
+    pub fn from_value<D>(data: N, dims: D) -> Self
     where
+        N: Copy,
+        D: Into<MatrixDims>,
+    {
+        let dims: MatrixDims = dims.into();
+        Self {
+            data: vec![data; dims.len().get()],
+            dims,
+        }
+    }
+    /// Constructs a new identity matrix
+    #[inline]
+    pub fn new_identity<NZ>(rows: NZ) -> Option<Self>
+    where
+        N: Number,
         NZ: TryInto<NonZeroUsize>,
     {
         let rows = rows.try_into().ok()?;
-        let dims = MatrixDims::from_row_count(data.len(), rows)?;
-        let data = BorrowedMatrixData::new(data);
-        Some(Self { data, dims })
+        let dims = MatrixDims::new(rows, rows);
+        let mut m = Self::from_value(N::ZERO, dims);
+        for r in 0..rows.get() {
+            m[(r, r)] = N::ONE;
+        }
+        Some(m)
+    }
+    /// Resizes the matrix.
+    /// Does not respect data on expansion.
+    #[inline]
+    pub fn resize<D>(&mut self, dims: D)
+    where
+        N: Copy + num_traits::ConstZero,
+        D: Into<MatrixDims>,
+    {
+        let dims: MatrixDims = dims.into();
+        if dims == self.dims() {
+            return;
+        }
+        self.data.resize(dims.len().get(), N::ZERO);
+        self.dims = dims;
     }
 }
 
-impl<T, N> Dimensions for MatrixBase<T, N>
-where
-    T: RawData<Elem = N>,
-{
+impl<T> Dimensions for MatrixBase<T> {
     /// Returns the matrix dimension.
     #[inline]
     fn dims(&self) -> MatrixDims { self.dims }
 }
 
-impl<T, N, I> Index<I> for MatrixBase<T, N>
+impl<T, I> Index<I> for MatrixBase<T>
 where
-    T: RawData<Elem = N>,
+    T: RawData,
     I: Into<MatrixCoord>,
 {
     type Output = T::Elem;
@@ -551,42 +560,43 @@ where
     #[inline]
     fn index(&self, index: I) -> &Self::Output {
         let index = index.into().to_linear_unchecked(self.dims);
-        &self.internal_data()[index]
+        &self.data.data()[index]
     }
 }
-impl<N, I> IndexMut<I> for Matrix<N>
+impl<T, I> IndexMut<I> for MatrixBase<T>
 where
+    T: RawDataMut,
     I: Into<MatrixCoord>,
 {
     #[inline]
     fn index_mut(&mut self, index: I) -> &mut Self::Output {
         let index = index.into().to_linear_unchecked(self.dims());
-        &mut self.data.data[index]
+        &mut self.data.data_mut()[index]
     }
 }
 
-impl<T, N> From<&MatrixBase<T, N>> for Matrix<N>
+impl<T> From<&MatrixBase<T>> for Matrix<T::Elem>
 where
-    T: RawData<Elem = N>,
-    N: Copy,
+    T: RawData,
+    T::Elem: Copy,
 {
     #[inline]
-    fn from(matrix: &MatrixBase<T, N>) -> Self { matrix.to_matrix() }
+    fn from(matrix: &MatrixBase<T>) -> Self { matrix.to_matrix() }
 }
-impl<'bdata, T, N> From<&'bdata MatrixBase<T, N>> for MatrixRef<'bdata, N>
+impl<'bdata, T> From<&'bdata MatrixBase<T>> for MatrixRef<'bdata, T::Elem>
 where
-    T: RawData<Elem = N>,
+    T: RawData,
 {
     #[inline]
-    fn from(matrix: &'bdata MatrixBase<T, N>) -> Self { matrix.to_matrixref() }
+    fn from(matrix: &'bdata MatrixBase<T>) -> Self { matrix.to_matrixref() }
 }
 
-impl<T, N> PointSet for MatrixBase<T, N>
+impl<T> PointSet for MatrixBase<T>
 where
-    T: RawData<Elem = N>,
-    N: Number,
+    T: RawData,
+    T::Elem: Number,
 {
-    type Value = N;
+    type Value = T::Elem;
     type Id = usize;
     /// Returns the number of rows in the matrix
     #[inline]
@@ -605,34 +615,36 @@ where
     /// Panics on oob.
     #[expect(clippy::renamed_function_params, reason = "a matrix has rows, not ids")]
     #[inline]
-    fn coord(&self, row: usize, col: usize) -> N {
+    fn coord(&self, row: usize, col: usize) -> Self::Value {
         let idx = row + col * self.dims.rows.get();
-        self.internal_data()[idx]
+        self.data.data()[idx]
     }
     /// Returns the element at coordinates `(row, col)`.
     /// Returns `None` if the coordinates are oob.
     #[expect(clippy::renamed_function_params, reason = "a matrix has rows, not ids")]
     #[inline]
-    fn get_coord(&self, row: usize, col: usize) -> Option<N> { self.get((row, col)).copied() }
+    fn get_coord(&self, row: usize, col: usize) -> Option<Self::Value> {
+        self.get((row, col)).copied()
+    }
     /// Returns an iterator over the coords of `row`, or `None` if `row` does not exist.
     #[expect(clippy::renamed_function_params, reason = "a matrix has rows, not ids")]
     #[must_use]
     #[inline]
-    fn get_coords(&self, row: usize) -> Option<impl ExactSizeIterator<Item = &N>> {
+    fn get_coords(&self, row: usize) -> Option<impl ExactSizeIterator<Item = &Self::Value>> {
         self.row_iter(row)
     }
     /// Returns the squared euclidean distance between rows `id_a` and `id_b`.
     /// Panics on oob.
     #[inline]
-    fn sq_distance_between(&self, id_a: usize, id_b: usize) -> N {
+    fn sq_distance_between(&self, id_a: usize, id_b: usize) -> Self::Value {
         if id_a == id_b {
-            return N::zero();
+            return <Self::Value as ConstZero>::ZERO;
         }
         let mut idx = id_a.min(id_b);
         let idx_diff = id_a.abs_diff(id_b);
-        let mut sum = N::zero();
+        let mut sum = <Self::Value as ConstZero>::ZERO;
         for _ in 0..self.ncol().get() {
-            let diff = self.internal_data()[idx] - self.internal_data()[idx + idx_diff];
+            let diff = self.data.data()[idx] - self.data.data()[idx + idx_diff];
             sum += diff * diff;
             idx += self.nrow().get();
         }
@@ -641,7 +653,7 @@ where
     /// Returns the squared euclidean distance between rows `id_a` and `id_b`.
     /// Returns `None` if any row is oob.
     #[inline]
-    fn get_sq_distance_between(&self, id_a: usize, id_b: usize) -> Option<N> {
+    fn get_sq_distance_between(&self, id_a: usize, id_b: usize) -> Option<Self::Value> {
         (self.contains(id_a) && self.contains(id_b)).then(|| self.sq_distance_between(id_a, id_b))
     }
 }

--- a/envisim_utils/src/matrix/mod.rs
+++ b/envisim_utils/src/matrix/mod.rs
@@ -74,6 +74,40 @@ impl<T> MatrixBase<T> {
         let dims = MatrixDims::from_row_count(data.data().len(), rows)?;
         Some(Self { data, dims })
     }
+    /// Constructs a new owned matrix representation filled with some value `data`.
+    #[inline]
+    pub fn from_value<D>(value: T::Elem, dims: D) -> Self
+    where
+        T: RawData + From<Vec<T::Elem>>,
+        T::Elem: Copy,
+        D: Into<MatrixDims>,
+    {
+        let dims: MatrixDims = dims.into();
+        let data = vec![value; dims.len().get()];
+        Self {
+            data: data.into(),
+            dims,
+        }
+    }
+    /// Constructs a new identity matrix
+    #[inline]
+    pub fn new_identity<NZ>(rows: NZ) -> Option<Self>
+    where
+        T: RawData + From<Vec<T::Elem>>,
+        T::Elem: ConstZero + ConstOne + Copy,
+        NZ: TryInto<NonZeroUsize>,
+    {
+        let rows = rows.try_into().ok()?;
+        let dims = MatrixDims::new(rows, rows);
+        let mut data = vec![T::Elem::ZERO; dims.len().get()];
+        for e in data.iter_mut().step_by(rows.get() + 1) {
+            *e = T::Elem::ONE;
+        }
+        Some(Self {
+            data: data.into(),
+            dims,
+        })
+    }
     /// Constructs a borrowed matrix representation from a matrix.
     #[inline]
     pub fn to_matrixref(&self) -> MatrixRef<'_, T::Elem>
@@ -497,34 +531,6 @@ impl<T> MatrixBase<T> {
 }
 
 impl<N> Matrix<N> {
-    /// Constructs a new owned matrix representation filled with some value `data`.
-    #[inline]
-    pub fn from_value<D>(data: N, dims: D) -> Self
-    where
-        N: Copy,
-        D: Into<MatrixDims>,
-    {
-        let dims: MatrixDims = dims.into();
-        Self {
-            data: vec![data; dims.len().get()],
-            dims,
-        }
-    }
-    /// Constructs a new identity matrix
-    #[inline]
-    pub fn new_identity<NZ>(rows: NZ) -> Option<Self>
-    where
-        N: Number,
-        NZ: TryInto<NonZeroUsize>,
-    {
-        let rows = rows.try_into().ok()?;
-        let dims = MatrixDims::new(rows, rows);
-        let mut m = Self::from_value(N::ZERO, dims);
-        for r in 0..rows.get() {
-            m[(r, r)] = N::ONE;
-        }
-        Some(m)
-    }
     /// Resizes the matrix.
     /// Does not respect data on expansion.
     #[inline]

--- a/envisim_utils/src/matrix/raw_data.rs
+++ b/envisim_utils/src/matrix/raw_data.rs
@@ -10,31 +10,92 @@
 // You should have received a copy of the GNU Affero General Public License along with this
 // program. If not, see <https://www.gnu.org/licenses/>.
 
-//! Raw data -- internal data structure
+//! Internal data structure traits
+
+use std::borrow::Cow;
+use std::rc::Rc;
+use std::sync::Arc;
 
 /// Data container trait
 pub trait RawData: Sized {
     type Elem;
+    /// Returns a reference (view) to the internal data, expected to be in column major order.
     #[must_use]
     fn data(&self) -> &[Self::Elem];
 }
 /// Mutable data container trait
 pub trait RawDataMut: RawData {
+    /// Returns a mutable reference to the internal data, expected to be in column major order.
     #[must_use]
     fn data_mut(&mut self) -> &mut [Self::Elem];
 }
 
-impl<N> RawData for Vec<N> {
+// View containers
+impl<N, const L: usize> RawData for [N; L] {
     type Elem = N;
     #[inline]
-    fn data(&self) -> &[Self::Elem] { self.as_slice() }
-}
-impl<N> RawDataMut for Vec<N> {
-    #[inline]
-    fn data_mut(&mut self) -> &mut [Self::Elem] { self.as_mut_slice() }
+    fn data(&self) -> &[Self::Elem] { self }
 }
 impl<N> RawData for &[N] {
     type Elem = N;
     #[inline]
     fn data(&self) -> &[Self::Elem] { self }
+}
+impl<N> RawData for &mut [N] {
+    type Elem = N;
+    #[inline]
+    fn data(&self) -> &[Self::Elem] { self }
+}
+impl<N> RawData for Vec<N> {
+    type Elem = N;
+    #[inline]
+    fn data(&self) -> &[Self::Elem] { self }
+}
+impl<N> RawData for Box<[N]> {
+    type Elem = N;
+    #[inline]
+    fn data(&self) -> &[Self::Elem] { self }
+}
+impl<N> RawData for Cow<'_, [N]>
+where
+    N: Clone,
+{
+    type Elem = N;
+    #[inline]
+    fn data(&self) -> &[Self::Elem] { self }
+}
+impl<N> RawData for Rc<[N]> {
+    type Elem = N;
+    #[inline]
+    fn data(&self) -> &[Self::Elem] { self }
+}
+impl<N> RawData for Arc<[N]> {
+    type Elem = N;
+    #[inline]
+    fn data(&self) -> &[Self::Elem] { self }
+}
+
+// Mutable containers
+impl<N, const L: usize> RawDataMut for [N; L] {
+    #[inline]
+    fn data_mut(&mut self) -> &mut [Self::Elem] { self }
+}
+impl<N> RawDataMut for &mut [N] {
+    #[inline]
+    fn data_mut(&mut self) -> &mut [Self::Elem] { self }
+}
+impl<N> RawDataMut for Vec<N> {
+    #[inline]
+    fn data_mut(&mut self) -> &mut [Self::Elem] { self }
+}
+impl<N> RawDataMut for Box<[N]> {
+    #[inline]
+    fn data_mut(&mut self) -> &mut [Self::Elem] { self }
+}
+impl<N> RawDataMut for Cow<'_, [N]>
+where
+    N: Clone,
+{
+    #[inline]
+    fn data_mut(&mut self) -> &mut [Self::Elem] { self.to_mut() }
 }

--- a/envisim_utils/src/matrix/raw_data.rs
+++ b/envisim_utils/src/matrix/raw_data.rs
@@ -18,69 +18,23 @@ pub trait RawData: Sized {
     #[must_use]
     fn data(&self) -> &[Self::Elem];
 }
-
-#[expect(
-    clippy::field_scoped_visibility_modifiers,
-    reason = "ok within matrix module"
-)]
-#[must_use]
-#[derive(Debug, Clone)]
-pub struct OwnedMatrixData<N> {
-    /// Internal data vector
-    pub(super) data: Vec<N>,
-}
-impl<N> OwnedMatrixData<N> {
-    /// Constructs a new owned matrix data
-    #[inline]
-    pub fn new(data: Vec<N>) -> Self { Self { data } }
+/// Mutable data container trait
+pub trait RawDataMut: RawData {
+    #[must_use]
+    fn data_mut(&mut self) -> &mut [Self::Elem];
 }
 
-impl<N> RawData for OwnedMatrixData<N> {
+impl<N> RawData for Vec<N> {
     type Elem = N;
     #[inline]
-    fn data(&self) -> &[Self::Elem] { &self.data }
+    fn data(&self) -> &[Self::Elem] { self.as_slice() }
 }
-impl<N> From<&BorrowedMatrixData<'_, N>> for OwnedMatrixData<N>
-where
-    N: Copy,
-{
+impl<N> RawDataMut for Vec<N> {
     #[inline]
-    fn from(data: &BorrowedMatrixData<N>) -> Self { Self::new(data.data().to_vec()) }
+    fn data_mut(&mut self) -> &mut [Self::Elem] { self.as_mut_slice() }
 }
-impl<N> From<&[N]> for OwnedMatrixData<N>
-where
-    N: Copy,
-{
-    #[inline]
-    fn from(data: &[N]) -> Self { Self::new(data.to_vec()) }
-}
-impl<N> From<Vec<N>> for OwnedMatrixData<N> {
-    #[inline]
-    fn from(data: Vec<N>) -> Self { Self::new(data) }
-}
-
-#[must_use]
-#[derive(Debug, Clone, Copy)]
-pub struct BorrowedMatrixData<'bdata, N> {
-    /// Internal data reference
-    data: &'bdata [N],
-}
-impl<'bdata, N> BorrowedMatrixData<'bdata, N> {
-    /// Constructs a new borrowed matrix data
-    #[inline]
-    pub fn new(data: &'bdata [N]) -> Self { Self { data } }
-}
-
-impl<N> RawData for BorrowedMatrixData<'_, N> {
+impl<N> RawData for &[N] {
     type Elem = N;
     #[inline]
-    fn data(&self) -> &[Self::Elem] { self.data }
-}
-impl<'borrow, N> From<&'borrow OwnedMatrixData<N>> for BorrowedMatrixData<'borrow, N> {
-    #[inline]
-    fn from(data: &'borrow OwnedMatrixData<N>) -> Self { Self::new(data.data()) }
-}
-impl<'bdata, N> From<&'bdata [N]> for BorrowedMatrixData<'bdata, N> {
-    #[inline]
-    fn from(data: &'bdata [N]) -> Self { Self::new(data) }
+    fn data(&self) -> &[Self::Elem] { self }
 }

--- a/envisim_utils/src/sampling_options/mod.rs
+++ b/envisim_utils/src/sampling_options/mod.rs
@@ -294,6 +294,58 @@ impl SamplingOptions<EqualProbabilityOptions> {
         let spec = EqualProbabilityOptions::new(population_size, sample_size)?;
         Ok(Self::with_spec_equal(spec))
     }
+    /// Initializes `SamplingOptions` with spreading `data` and an equal probability specification
+    /// determined by the size of the spreading `data` and the `sample_size`.
+    ///
+    /// # Errors
+    /// If [`ProbabilitySpecEqual`] cannot be constructed, i.e. if `sample_size` is larger than the
+    /// population size.
+    #[inline]
+    pub fn with_spreading<AUXP, I>(
+        data: I,
+        sample_size: usize,
+    ) -> SamplingOptionsResult<SamplingOptions<EqualProbabilityOptions, SpreadingOptions<AUXP>, ()>>
+    where
+        AUXP: PointSet,
+        I: Into<SpreadingOptions<AUXP>>,
+    {
+        let data = data.into();
+        let population_size = data.data().len();
+        let spec = EqualProbabilityOptions::new(population_size, sample_size)?;
+        Ok(SamplingOptions {
+            probabilities: spec,
+            eps: Epsilon::<f64>::default(),
+            max_iterations: MAX_ITERATIONS,
+            spreading: data,
+            balancing: (),
+        })
+    }
+    /// Initializes `SamplingOptions` with balancing `data` and an equal probability specification
+    /// determined by the size of the balancing `data` and the `sample_size`.
+    ///
+    /// # Errors
+    /// If [`ProbabilitySpecEqual`] cannot be constructed, i.e. if `sample_size` is larger than the
+    /// population size.
+    #[inline]
+    pub fn with_balancing<BALP, I>(
+        data: I,
+        sample_size: usize,
+    ) -> SamplingOptionsResult<SamplingOptions<EqualProbabilityOptions, (), BalancingOptions<BALP>>>
+    where
+        BALP: Dimensions,
+        I: Into<BalancingOptions<BALP>>,
+    {
+        let data = data.into();
+        let population_size = data.data().nrow();
+        let spec = EqualProbabilityOptions::new(population_size, sample_size)?;
+        Ok(SamplingOptions {
+            probabilities: spec,
+            eps: Epsilon::<f64>::default(),
+            max_iterations: MAX_ITERATIONS,
+            spreading: (),
+            balancing: data,
+        })
+    }
     /// Initializes `SamplingOptions` with equal probability options
     #[inline]
     pub fn with_spec_equal(

--- a/rsamplr_pkg/CHANGELOG.md
+++ b/rsamplr_pkg/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Bumped envisim-dependencies.
+
+
 ## [0.3.1] - 2026-06-02
 - Bumped envisim-dependencies.
 

--- a/rsamplr_pkg/LICENSE.note
+++ b/rsamplr_pkg/LICENSE.note
@@ -3,35 +3,67 @@ The following Rust crates are used or included in this package:
 
 -------------------------------------------------------------
 
+Name:        anyhow
+Version:     1.0.102
+Repository:  https://github.com/dtolnay/anyhow
+Authors:     David Tolnay
+License:     Apache-2.0 OR MIT
+
+-------------------------------------------------------------
+
+Name:        autocfg
+Version:     1.5.0
+Repository:  https://github.com/cuviper/autocfg
+Authors:     Josh Stone
+License:     Apache-2.0 OR MIT
+
+-------------------------------------------------------------
+
+Name:        bitflags
+Version:     2.11.1
+Repository:  https://github.com/bitflags/bitflags
+Authors:     The Rust Project Developers
+License:     Apache-2.0 OR MIT
+
+-------------------------------------------------------------
+
 Name:        cc
-Version:     1.2.58
+Version:     1.2.61
 Repository:  https://github.com/rust-lang/cc-rs
 Authors:     Alex Crichton
 License:     Apache-2.0 OR MIT
 
 -------------------------------------------------------------
 
-Name:        envisim_estimate
-Version:     0.4.0
-Repository:  https://github.com/envisim/rust-samplr
-Authors:     Wilmer Prentius
-License:     AGPL-3.0
+Name:        cfg-if
+Version:     1.0.4
+Repository:  https://github.com/rust-lang/cfg-if
+Authors:     Alex Crichton
+License:     Apache-2.0 OR MIT
 
 -------------------------------------------------------------
 
-Name:        envisim_samplr
-Version:     0.5.0
-Repository:  https://github.com/envisim/rust-samplr
-Authors:     Wilmer Prentius
-License:     AGPL-3.0
+Name:        chacha20
+Version:     0.10.0
+Repository:  https://github.com/RustCrypto/stream-ciphers
+Authors:     RustCrypto Developers
+License:     Apache-2.0 OR MIT
 
 -------------------------------------------------------------
 
-Name:        envisim_utils
-Version:     0.4.0
-Repository:  https://github.com/envisim/rust-samplr
-Authors:     Wilmer Prentius
-License:     AGPL-3.0
+Name:        cpufeatures
+Version:     0.3.0
+Repository:  https://github.com/RustCrypto/utils
+Authors:     RustCrypto Developers
+License:     Apache-2.0 OR MIT
+
+-------------------------------------------------------------
+
+Name:        equivalent
+Version:     1.0.2
+Repository:  https://github.com/indexmap-rs/equivalent
+Authors:     equivalent authors
+License:     Apache-2.0 OR MIT
 
 -------------------------------------------------------------
 
@@ -39,6 +71,126 @@ Name:        find-msvc-tools
 Version:     0.1.9
 Repository:  https://github.com/rust-lang/cc-rs
 Authors:     find-msvc-tools authors
+License:     Apache-2.0 OR MIT
+
+-------------------------------------------------------------
+
+Name:        foldhash
+Version:     0.1.5
+Repository:  https://github.com/orlp/foldhash
+Authors:     Orson Peters
+License:     Zlib
+
+-------------------------------------------------------------
+
+Name:        getrandom
+Version:     0.4.2
+Repository:  https://github.com/rust-random/getrandom
+Authors:     The Rand Project Developers
+License:     Apache-2.0 OR MIT
+
+-------------------------------------------------------------
+
+Name:        hashbrown
+Version:     0.15.5
+Repository:  https://github.com/rust-lang/hashbrown
+Authors:     Amanieu d'Antras
+License:     Apache-2.0 OR MIT
+
+-------------------------------------------------------------
+
+Name:        hashbrown
+Version:     0.17.1
+Repository:  https://github.com/rust-lang/hashbrown
+Authors:     hashbrown authors
+License:     Apache-2.0 OR MIT
+
+-------------------------------------------------------------
+
+Name:        heck
+Version:     0.5.0
+Repository:  https://github.com/withoutboats/heck
+Authors:     heck authors
+License:     Apache-2.0 OR MIT
+
+-------------------------------------------------------------
+
+Name:        id-arena
+Version:     2.3.0
+Repository:  https://github.com/fitzgen/id-arena
+Authors:     Nick Fitzgerald, Aleksey Kladov
+License:     Apache-2.0 OR MIT
+
+-------------------------------------------------------------
+
+Name:        indexmap
+Version:     2.14.0
+Repository:  https://github.com/indexmap-rs/indexmap
+Authors:     indexmap authors
+License:     Apache-2.0 OR MIT
+
+-------------------------------------------------------------
+
+Name:        itoa
+Version:     1.0.18
+Repository:  https://github.com/dtolnay/itoa
+Authors:     David Tolnay
+License:     Apache-2.0 OR MIT
+
+-------------------------------------------------------------
+
+Name:        leb128fmt
+Version:     0.1.0
+Repository:  https://github.com/bluk/leb128fmt
+Authors:     Bryant Luk
+License:     Apache-2.0 OR MIT
+
+-------------------------------------------------------------
+
+Name:        libc
+Version:     0.2.186
+Repository:  https://github.com/rust-lang/libc
+Authors:     The Rust Project Developers
+License:     Apache-2.0 OR MIT
+
+-------------------------------------------------------------
+
+Name:        log
+Version:     0.4.29
+Repository:  https://github.com/rust-lang/log
+Authors:     The Rust Project Developers
+License:     Apache-2.0 OR MIT
+
+-------------------------------------------------------------
+
+Name:        memchr
+Version:     2.8.0
+Repository:  https://github.com/BurntSushi/memchr
+Authors:     Andrew Gallant, bluss
+License:     MIT OR Unlicense
+
+-------------------------------------------------------------
+
+Name:        num-integer
+Version:     0.1.46
+Repository:  https://github.com/rust-num/num-integer
+Authors:     The Rust Project Developers
+License:     Apache-2.0 OR MIT
+
+-------------------------------------------------------------
+
+Name:        num-traits
+Version:     0.2.19
+Repository:  https://github.com/rust-num/num-traits
+Authors:     The Rust Project Developers
+License:     Apache-2.0 OR MIT
+
+-------------------------------------------------------------
+
+Name:        prettyplease
+Version:     0.2.37
+Repository:  https://github.com/dtolnay/prettyplease
+Authors:     David Tolnay
 License:     Apache-2.0 OR MIT
 
 -------------------------------------------------------------
@@ -59,6 +211,30 @@ License:     Apache-2.0 OR MIT
 
 -------------------------------------------------------------
 
+Name:        r-efi
+Version:     6.0.0
+Repository:  https://github.com/r-efi/r-efi
+Authors:     r-efi authors
+License:     Apache-2.0 OR LGPL-2.1-or-later OR MIT
+
+-------------------------------------------------------------
+
+Name:        rand
+Version:     0.10.1
+Repository:  https://github.com/rust-random/rand
+Authors:     The Rand Project Developers, The Rust Project Developers
+License:     Apache-2.0 OR MIT
+
+-------------------------------------------------------------
+
+Name:        rand_core
+Version:     0.10.1
+Repository:  https://github.com/rust-random/rand_core
+Authors:     The Rand Project Developers
+License:     Apache-2.0 OR MIT
+
+-------------------------------------------------------------
+
 Name:        rustc-hash
 Version:     2.1.2
 Repository:  https://github.com/rust-lang/rustc-hash
@@ -68,7 +244,7 @@ License:     Apache-2.0 OR MIT
 -------------------------------------------------------------
 
 Name:        savvy
-Version:     0.9.2
+Version:     0.9.4
 Repository:  https://github.com/yutannihilation/savvy/
 Authors:     Hiroaki Yutani
 License:     MIT
@@ -76,7 +252,7 @@ License:     MIT
 -------------------------------------------------------------
 
 Name:        savvy-bindgen
-Version:     0.9.2
+Version:     0.9.4
 Repository:  https://github.com/yutannihilation/savvy/
 Authors:     Hiroaki Yutani
 License:     MIT
@@ -84,7 +260,7 @@ License:     MIT
 -------------------------------------------------------------
 
 Name:        savvy-ffi
-Version:     0.9.2
+Version:     0.9.4
 Repository:  https://github.com/yutannihilation/savvy/
 Authors:     Hiroaki Yutani
 License:     MIT
@@ -92,10 +268,50 @@ License:     MIT
 -------------------------------------------------------------
 
 Name:        savvy-macro
-Version:     0.9.2
+Version:     0.9.4
 Repository:  https://github.com/yutannihilation/savvy/
 Authors:     Hiroaki Yutani
 License:     MIT
+
+-------------------------------------------------------------
+
+Name:        semver
+Version:     1.0.28
+Repository:  https://github.com/dtolnay/semver
+Authors:     David Tolnay
+License:     Apache-2.0 OR MIT
+
+-------------------------------------------------------------
+
+Name:        serde
+Version:     1.0.228
+Repository:  https://github.com/serde-rs/serde
+Authors:     Erick Tryzelaar, David Tolnay
+License:     Apache-2.0 OR MIT
+
+-------------------------------------------------------------
+
+Name:        serde_core
+Version:     1.0.228
+Repository:  https://github.com/serde-rs/serde
+Authors:     Erick Tryzelaar, David Tolnay
+License:     Apache-2.0 OR MIT
+
+-------------------------------------------------------------
+
+Name:        serde_derive
+Version:     1.0.228
+Repository:  https://github.com/serde-rs/serde
+Authors:     Erick Tryzelaar, David Tolnay
+License:     Apache-2.0 OR MIT
+
+-------------------------------------------------------------
+
+Name:        serde_json
+Version:     1.0.149
+Repository:  https://github.com/serde-rs/json
+Authors:     Erick Tryzelaar, David Tolnay
+License:     Apache-2.0 OR MIT
 
 -------------------------------------------------------------
 
@@ -120,5 +336,117 @@ Version:     1.0.24
 Repository:  https://github.com/dtolnay/unicode-ident
 Authors:     David Tolnay
 License:     (Apache-2.0 OR MIT) AND Unicode-3.0
+
+-------------------------------------------------------------
+
+Name:        unicode-xid
+Version:     0.2.6
+Repository:  https://github.com/unicode-rs/unicode-xid
+Authors:     erick.tryzelaar, kwantam, Manish Goregaokar
+License:     Apache-2.0 OR MIT
+
+-------------------------------------------------------------
+
+Name:        wasip2
+Version:     1.0.3+wasi-0.2.9
+Repository:  https://github.com/bytecodealliance/wasi-rs
+Authors:     wasip2 authors
+License:     Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
+
+-------------------------------------------------------------
+
+Name:        wasip3
+Version:     0.4.0+wasi-0.3.0-rc-2026-01-06
+Repository:  https://github.com/bytecodealliance/wasi-rs
+Authors:     wasip3 authors
+License:     Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
+
+-------------------------------------------------------------
+
+Name:        wasm-encoder
+Version:     0.244.0
+Repository:  https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-encoder
+Authors:     Nick Fitzgerald
+License:     Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
+
+-------------------------------------------------------------
+
+Name:        wasm-metadata
+Version:     0.244.0
+Repository:  https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-metadata
+Authors:     wasm-metadata authors
+License:     Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
+
+-------------------------------------------------------------
+
+Name:        wasmparser
+Version:     0.244.0
+Repository:  https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser
+Authors:     Yury Delendik
+License:     Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
+
+-------------------------------------------------------------
+
+Name:        wit-bindgen
+Version:     0.51.0
+Repository:  https://github.com/bytecodealliance/wit-bindgen
+Authors:     Alex Crichton
+License:     Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
+
+-------------------------------------------------------------
+
+Name:        wit-bindgen
+Version:     0.57.1
+Repository:  https://github.com/bytecodealliance/wit-bindgen
+Authors:     Alex Crichton
+License:     Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
+
+-------------------------------------------------------------
+
+Name:        wit-bindgen-core
+Version:     0.51.0
+Repository:  https://github.com/bytecodealliance/wit-bindgen
+Authors:     Alex Crichton
+License:     Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
+
+-------------------------------------------------------------
+
+Name:        wit-bindgen-rust
+Version:     0.51.0
+Repository:  https://github.com/bytecodealliance/wit-bindgen
+Authors:     Alex Crichton
+License:     Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
+
+-------------------------------------------------------------
+
+Name:        wit-bindgen-rust-macro
+Version:     0.51.0
+Repository:  https://github.com/bytecodealliance/wit-bindgen
+Authors:     Alex Crichton
+License:     Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
+
+-------------------------------------------------------------
+
+Name:        wit-component
+Version:     0.244.0
+Repository:  https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-component
+Authors:     Peter Huene
+License:     Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
+
+-------------------------------------------------------------
+
+Name:        wit-parser
+Version:     0.244.0
+Repository:  https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-parser
+Authors:     Alex Crichton
+License:     Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
+
+-------------------------------------------------------------
+
+Name:        zmij
+Version:     1.0.21
+Repository:  https://github.com/dtolnay/zmij
+Authors:     David Tolnay
+License:     MIT
 
 -------------------------------------------------------------

--- a/rsamplr_pkg/LICENSE.note
+++ b/rsamplr_pkg/LICENSE.note
@@ -19,11 +19,27 @@ License:     Apache-2.0 OR MIT
 
 -------------------------------------------------------------
 
-Name:        cfg-if
-Version:     1.0.4
-Repository:  https://github.com/rust-lang/cfg-if
-Authors:     Alex Crichton
-License:     Apache-2.0 OR MIT
+Name:        envisim_estimate
+Version:     0.6.0
+Repository:  https://github.com/envisim/rust-samplr
+Authors:     Wilmer Prentius
+License:     AGPL-3.0
+
+-------------------------------------------------------------
+
+Name:        envisim_samplr
+Version:     0.7.0
+Repository:  https://github.com/envisim/rust-samplr
+Authors:     Wilmer Prentius
+License:     AGPL-3.0
+
+-------------------------------------------------------------
+
+Name:        envisim_utils
+Version:     0.6.0
+Repository:  https://github.com/envisim/rust-samplr
+Authors:     Wilmer Prentius
+License:     AGPL-3.0
 
 -------------------------------------------------------------
 
@@ -31,22 +47,6 @@ Name:        find-msvc-tools
 Version:     0.1.9
 Repository:  https://github.com/rust-lang/cc-rs
 Authors:     find-msvc-tools authors
-License:     Apache-2.0 OR MIT
-
--------------------------------------------------------------
-
-Name:        getrandom
-Version:     0.4.3
-Repository:  https://github.com/rust-random/getrandom
-Authors:     The Rand Project Developers
-License:     Apache-2.0 OR MIT
-
--------------------------------------------------------------
-
-Name:        libc
-Version:     0.2.186
-Repository:  https://github.com/rust-lang/libc
-Authors:     The Rust Project Developers
 License:     Apache-2.0 OR MIT
 
 -------------------------------------------------------------
@@ -79,22 +79,6 @@ Name:        quote
 Version:     1.0.46
 Repository:  https://github.com/dtolnay/quote
 Authors:     David Tolnay
-License:     Apache-2.0 OR MIT
-
--------------------------------------------------------------
-
-Name:        r-efi
-Version:     6.0.0
-Repository:  https://github.com/r-efi/r-efi
-Authors:     r-efi authors
-License:     Apache-2.0 OR LGPL-2.1-or-later OR MIT
-
--------------------------------------------------------------
-
-Name:        rand
-Version:     0.10.2
-Repository:  https://github.com/rust-random/rand
-Authors:     The Rand Project Developers, The Rust Project Developers
 License:     Apache-2.0 OR MIT
 
 -------------------------------------------------------------

--- a/rsamplr_pkg/LICENSE.note
+++ b/rsamplr_pkg/LICENSE.note
@@ -3,32 +3,16 @@ The following Rust crates are used or included in this package:
 
 -------------------------------------------------------------
 
-Name:        anyhow
-Version:     1.0.102
-Repository:  https://github.com/dtolnay/anyhow
-Authors:     David Tolnay
-License:     Apache-2.0 OR MIT
-
--------------------------------------------------------------
-
 Name:        autocfg
-Version:     1.5.0
+Version:     1.5.1
 Repository:  https://github.com/cuviper/autocfg
 Authors:     Josh Stone
 License:     Apache-2.0 OR MIT
 
 -------------------------------------------------------------
 
-Name:        bitflags
-Version:     2.11.1
-Repository:  https://github.com/bitflags/bitflags
-Authors:     The Rust Project Developers
-License:     Apache-2.0 OR MIT
-
--------------------------------------------------------------
-
 Name:        cc
-Version:     1.2.61
+Version:     1.2.65
 Repository:  https://github.com/rust-lang/cc-rs
 Authors:     Alex Crichton
 License:     Apache-2.0 OR MIT
@@ -43,30 +27,6 @@ License:     Apache-2.0 OR MIT
 
 -------------------------------------------------------------
 
-Name:        chacha20
-Version:     0.10.0
-Repository:  https://github.com/RustCrypto/stream-ciphers
-Authors:     RustCrypto Developers
-License:     Apache-2.0 OR MIT
-
--------------------------------------------------------------
-
-Name:        cpufeatures
-Version:     0.3.0
-Repository:  https://github.com/RustCrypto/utils
-Authors:     RustCrypto Developers
-License:     Apache-2.0 OR MIT
-
--------------------------------------------------------------
-
-Name:        equivalent
-Version:     1.0.2
-Repository:  https://github.com/indexmap-rs/equivalent
-Authors:     equivalent authors
-License:     Apache-2.0 OR MIT
-
--------------------------------------------------------------
-
 Name:        find-msvc-tools
 Version:     0.1.9
 Repository:  https://github.com/rust-lang/cc-rs
@@ -75,74 +35,10 @@ License:     Apache-2.0 OR MIT
 
 -------------------------------------------------------------
 
-Name:        foldhash
-Version:     0.1.5
-Repository:  https://github.com/orlp/foldhash
-Authors:     Orson Peters
-License:     Zlib
-
--------------------------------------------------------------
-
 Name:        getrandom
-Version:     0.4.2
+Version:     0.4.3
 Repository:  https://github.com/rust-random/getrandom
 Authors:     The Rand Project Developers
-License:     Apache-2.0 OR MIT
-
--------------------------------------------------------------
-
-Name:        hashbrown
-Version:     0.15.5
-Repository:  https://github.com/rust-lang/hashbrown
-Authors:     Amanieu d'Antras
-License:     Apache-2.0 OR MIT
-
--------------------------------------------------------------
-
-Name:        hashbrown
-Version:     0.17.1
-Repository:  https://github.com/rust-lang/hashbrown
-Authors:     hashbrown authors
-License:     Apache-2.0 OR MIT
-
--------------------------------------------------------------
-
-Name:        heck
-Version:     0.5.0
-Repository:  https://github.com/withoutboats/heck
-Authors:     heck authors
-License:     Apache-2.0 OR MIT
-
--------------------------------------------------------------
-
-Name:        id-arena
-Version:     2.3.0
-Repository:  https://github.com/fitzgen/id-arena
-Authors:     Nick Fitzgerald, Aleksey Kladov
-License:     Apache-2.0 OR MIT
-
--------------------------------------------------------------
-
-Name:        indexmap
-Version:     2.14.0
-Repository:  https://github.com/indexmap-rs/indexmap
-Authors:     indexmap authors
-License:     Apache-2.0 OR MIT
-
--------------------------------------------------------------
-
-Name:        itoa
-Version:     1.0.18
-Repository:  https://github.com/dtolnay/itoa
-Authors:     David Tolnay
-License:     Apache-2.0 OR MIT
-
--------------------------------------------------------------
-
-Name:        leb128fmt
-Version:     0.1.0
-Repository:  https://github.com/bluk/leb128fmt
-Authors:     Bryant Luk
 License:     Apache-2.0 OR MIT
 
 -------------------------------------------------------------
@@ -152,22 +48,6 @@ Version:     0.2.186
 Repository:  https://github.com/rust-lang/libc
 Authors:     The Rust Project Developers
 License:     Apache-2.0 OR MIT
-
--------------------------------------------------------------
-
-Name:        log
-Version:     0.4.29
-Repository:  https://github.com/rust-lang/log
-Authors:     The Rust Project Developers
-License:     Apache-2.0 OR MIT
-
--------------------------------------------------------------
-
-Name:        memchr
-Version:     2.8.0
-Repository:  https://github.com/BurntSushi/memchr
-Authors:     Andrew Gallant, bluss
-License:     MIT OR Unlicense
 
 -------------------------------------------------------------
 
@@ -187,14 +67,6 @@ License:     Apache-2.0 OR MIT
 
 -------------------------------------------------------------
 
-Name:        prettyplease
-Version:     0.2.37
-Repository:  https://github.com/dtolnay/prettyplease
-Authors:     David Tolnay
-License:     Apache-2.0 OR MIT
-
--------------------------------------------------------------
-
 Name:        proc-macro2
 Version:     1.0.106
 Repository:  https://github.com/dtolnay/proc-macro2
@@ -204,7 +76,7 @@ License:     Apache-2.0 OR MIT
 -------------------------------------------------------------
 
 Name:        quote
-Version:     1.0.45
+Version:     1.0.46
 Repository:  https://github.com/dtolnay/quote
 Authors:     David Tolnay
 License:     Apache-2.0 OR MIT
@@ -220,7 +92,7 @@ License:     Apache-2.0 OR LGPL-2.1-or-later OR MIT
 -------------------------------------------------------------
 
 Name:        rand
-Version:     0.10.1
+Version:     0.10.2
 Repository:  https://github.com/rust-random/rand
 Authors:     The Rand Project Developers, The Rust Project Developers
 License:     Apache-2.0 OR MIT
@@ -275,48 +147,8 @@ License:     MIT
 
 -------------------------------------------------------------
 
-Name:        semver
-Version:     1.0.28
-Repository:  https://github.com/dtolnay/semver
-Authors:     David Tolnay
-License:     Apache-2.0 OR MIT
-
--------------------------------------------------------------
-
-Name:        serde
-Version:     1.0.228
-Repository:  https://github.com/serde-rs/serde
-Authors:     Erick Tryzelaar, David Tolnay
-License:     Apache-2.0 OR MIT
-
--------------------------------------------------------------
-
-Name:        serde_core
-Version:     1.0.228
-Repository:  https://github.com/serde-rs/serde
-Authors:     Erick Tryzelaar, David Tolnay
-License:     Apache-2.0 OR MIT
-
--------------------------------------------------------------
-
-Name:        serde_derive
-Version:     1.0.228
-Repository:  https://github.com/serde-rs/serde
-Authors:     Erick Tryzelaar, David Tolnay
-License:     Apache-2.0 OR MIT
-
--------------------------------------------------------------
-
-Name:        serde_json
-Version:     1.0.149
-Repository:  https://github.com/serde-rs/json
-Authors:     Erick Tryzelaar, David Tolnay
-License:     Apache-2.0 OR MIT
-
--------------------------------------------------------------
-
 Name:        shlex
-Version:     1.3.0
+Version:     2.0.1
 Repository:  https://github.com/comex/rust-shlex
 Authors:     comex, Fenhl, Adrian Taylor, Alex Touchet, Daniel Parks, Garrett Berg
 License:     Apache-2.0 OR MIT
@@ -324,7 +156,7 @@ License:     Apache-2.0 OR MIT
 -------------------------------------------------------------
 
 Name:        syn
-Version:     2.0.117
+Version:     2.0.118
 Repository:  https://github.com/dtolnay/syn
 Authors:     David Tolnay
 License:     Apache-2.0 OR MIT
@@ -336,117 +168,5 @@ Version:     1.0.24
 Repository:  https://github.com/dtolnay/unicode-ident
 Authors:     David Tolnay
 License:     (Apache-2.0 OR MIT) AND Unicode-3.0
-
--------------------------------------------------------------
-
-Name:        unicode-xid
-Version:     0.2.6
-Repository:  https://github.com/unicode-rs/unicode-xid
-Authors:     erick.tryzelaar, kwantam, Manish Goregaokar
-License:     Apache-2.0 OR MIT
-
--------------------------------------------------------------
-
-Name:        wasip2
-Version:     1.0.3+wasi-0.2.9
-Repository:  https://github.com/bytecodealliance/wasi-rs
-Authors:     wasip2 authors
-License:     Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
-
--------------------------------------------------------------
-
-Name:        wasip3
-Version:     0.4.0+wasi-0.3.0-rc-2026-01-06
-Repository:  https://github.com/bytecodealliance/wasi-rs
-Authors:     wasip3 authors
-License:     Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
-
--------------------------------------------------------------
-
-Name:        wasm-encoder
-Version:     0.244.0
-Repository:  https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-encoder
-Authors:     Nick Fitzgerald
-License:     Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
-
--------------------------------------------------------------
-
-Name:        wasm-metadata
-Version:     0.244.0
-Repository:  https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-metadata
-Authors:     wasm-metadata authors
-License:     Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
-
--------------------------------------------------------------
-
-Name:        wasmparser
-Version:     0.244.0
-Repository:  https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser
-Authors:     Yury Delendik
-License:     Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
-
--------------------------------------------------------------
-
-Name:        wit-bindgen
-Version:     0.51.0
-Repository:  https://github.com/bytecodealliance/wit-bindgen
-Authors:     Alex Crichton
-License:     Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
-
--------------------------------------------------------------
-
-Name:        wit-bindgen
-Version:     0.57.1
-Repository:  https://github.com/bytecodealliance/wit-bindgen
-Authors:     Alex Crichton
-License:     Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
-
--------------------------------------------------------------
-
-Name:        wit-bindgen-core
-Version:     0.51.0
-Repository:  https://github.com/bytecodealliance/wit-bindgen
-Authors:     Alex Crichton
-License:     Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
-
--------------------------------------------------------------
-
-Name:        wit-bindgen-rust
-Version:     0.51.0
-Repository:  https://github.com/bytecodealliance/wit-bindgen
-Authors:     Alex Crichton
-License:     Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
-
--------------------------------------------------------------
-
-Name:        wit-bindgen-rust-macro
-Version:     0.51.0
-Repository:  https://github.com/bytecodealliance/wit-bindgen
-Authors:     Alex Crichton
-License:     Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
-
--------------------------------------------------------------
-
-Name:        wit-component
-Version:     0.244.0
-Repository:  https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-component
-Authors:     Peter Huene
-License:     Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
-
--------------------------------------------------------------
-
-Name:        wit-parser
-Version:     0.244.0
-Repository:  https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-parser
-Authors:     Alex Crichton
-License:     Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
-
--------------------------------------------------------------
-
-Name:        zmij
-Version:     1.0.21
-Repository:  https://github.com/dtolnay/zmij
-Authors:     David Tolnay
-License:     MIT
 
 -------------------------------------------------------------

--- a/rsamplr_pkg/dev/vendoring.R
+++ b/rsamplr_pkg/dev/vendoring.R
@@ -11,10 +11,10 @@ vendor_crates <- function(path = ".") {
   withr::local_dir(src_dir)
 
   config_toml_content <- processx::run(
-    "cargo-vendor-filterer",
+    "cargo",
     c(
+      "vendor",
       "--manifest-path", file.path("rust", "Cargo.toml"),
-      "--keep-dep-kinds", "no-dev",
       vendor_rel_path
     )
   )$stdout

--- a/rsamplr_pkg/dev/vendoring.R
+++ b/rsamplr_pkg/dev/vendoring.R
@@ -11,11 +11,10 @@ vendor_crates <- function(path = ".") {
   withr::local_dir(src_dir)
 
   config_toml_content <- processx::run(
-    "cargo",
+    "cargo-vendor-filterer",
     c(
-      "vendor",
-      "--locked",
       "--manifest-path", file.path("rust", "Cargo.toml"),
+      "--keep-dep-kinds", "no-dev",
       vendor_rel_path
     )
   )$stdout

--- a/rsamplr_pkg/inst/AUTHORS.md
+++ b/rsamplr_pkg/inst/AUTHORS.md
@@ -1,53 +1,25 @@
 # Authors of vendored cargo crates
-- anyhow 1.0.102: David Tolnay
-- autocfg 1.5.0: Josh Stone
-- bitflags 2.11.1: The Rust Project Developers
-- cc 1.2.61: Alex Crichton
+- autocfg 1.5.1: Josh Stone
+- cc 1.2.65: Alex Crichton
 - cfg-if 1.0.4: Alex Crichton
-- chacha20 0.10.0: RustCrypto Developers
-- cpufeatures 0.3.0: RustCrypto Developers
 - envisim_estimate 0.6.0: Wilmer Prentius
 - envisim_samplr 0.7.0: Wilmer Prentius
 - envisim_utils 0.6.0: Wilmer Prentius
-- foldhash 0.1.5: Orson Peters
-- getrandom 0.4.2: The Rand Project Developers
-- hashbrown 0.15.5: Amanieu d'Antras
-- id-arena 2.3.0: Nick Fitzgerald, Aleksey Kladov
-- itoa 1.0.18: David Tolnay
-- leb128fmt 0.1.0: Bryant Luk
+- getrandom 0.4.3: The Rand Project Developers
 - libc 0.2.186: The Rust Project Developers
-- log 0.4.29: The Rust Project Developers
-- memchr 2.8.0: Andrew Gallant, bluss
 - num-integer 0.1.46: The Rust Project Developers
 - num-traits 0.2.19: The Rust Project Developers
-- prettyplease 0.2.37: David Tolnay
 - proc-macro2 1.0.106: David Tolnay, Alex Crichton
-- quote 1.0.45: David Tolnay
-- rand 0.10.1: The Rand Project Developers, The Rust Project Developers
+- quote 1.0.46: David Tolnay
+- rand 0.10.2: The Rand Project Developers, The Rust Project Developers
 - rand_core 0.10.1: The Rand Project Developers
 - rustc-hash 2.1.2: The Rust Project Developers
 - savvy 0.9.4: Hiroaki Yutani
 - savvy-bindgen 0.9.4: Hiroaki Yutani
 - savvy-ffi 0.9.4: Hiroaki Yutani
 - savvy-macro 0.9.4: Hiroaki Yutani
-- semver 1.0.28: David Tolnay
-- serde 1.0.228: Erick Tryzelaar, David Tolnay
-- serde_core 1.0.228: Erick Tryzelaar, David Tolnay
-- serde_derive 1.0.228: Erick Tryzelaar, David Tolnay
-- serde_json 1.0.149: Erick Tryzelaar, David Tolnay
-- shlex 1.3.0: comex, Fenhl, Adrian Taylor, Alex Touchet, Daniel Parks, Garrett Berg
-- syn 2.0.117: David Tolnay
+- shlex 2.0.1: comex, Fenhl, Adrian Taylor, Alex Touchet, Daniel Parks, Garrett Berg
+- syn 2.0.118: David Tolnay
 - unicode-ident 1.0.24: David Tolnay
-- unicode-xid 0.2.6: erick.tryzelaar, kwantam, Manish Goregaokar
-- wasm-encoder 0.244.0: Nick Fitzgerald
-- wasmparser 0.244.0: Yury Delendik
-- wit-bindgen 0.51.0: Alex Crichton
-- wit-bindgen 0.57.1: Alex Crichton
-- wit-bindgen-core 0.51.0: Alex Crichton
-- wit-bindgen-rust 0.51.0: Alex Crichton
-- wit-bindgen-rust-macro 0.51.0: Alex Crichton
-- wit-component 0.244.0: Peter Huene
-- wit-parser 0.244.0: Alex Crichton
-- zmij 1.0.21: David Tolnay
 
 (This file was auto-generated from 'cargo metadata' on 2026-07-02)

--- a/rsamplr_pkg/inst/AUTHORS.md
+++ b/rsamplr_pkg/inst/AUTHORS.md
@@ -1,17 +1,53 @@
 # Authors of vendored cargo crates
-- cc 1.2.58: Alex Crichton
-- envisim_estimate 0.4.0: Wilmer Prentius
-- envisim_samplr 0.5.0: Wilmer Prentius
-- envisim_utils 0.4.0: Wilmer Prentius
+- anyhow 1.0.102: David Tolnay
+- autocfg 1.5.0: Josh Stone
+- bitflags 2.11.1: The Rust Project Developers
+- cc 1.2.61: Alex Crichton
+- cfg-if 1.0.4: Alex Crichton
+- chacha20 0.10.0: RustCrypto Developers
+- cpufeatures 0.3.0: RustCrypto Developers
+- envisim_estimate 0.6.0: Wilmer Prentius
+- envisim_samplr 0.7.0: Wilmer Prentius
+- envisim_utils 0.6.0: Wilmer Prentius
+- foldhash 0.1.5: Orson Peters
+- getrandom 0.4.2: The Rand Project Developers
+- hashbrown 0.15.5: Amanieu d'Antras
+- id-arena 2.3.0: Nick Fitzgerald, Aleksey Kladov
+- itoa 1.0.18: David Tolnay
+- leb128fmt 0.1.0: Bryant Luk
+- libc 0.2.186: The Rust Project Developers
+- log 0.4.29: The Rust Project Developers
+- memchr 2.8.0: Andrew Gallant, bluss
+- num-integer 0.1.46: The Rust Project Developers
+- num-traits 0.2.19: The Rust Project Developers
+- prettyplease 0.2.37: David Tolnay
 - proc-macro2 1.0.106: David Tolnay, Alex Crichton
 - quote 1.0.45: David Tolnay
+- rand 0.10.1: The Rand Project Developers, The Rust Project Developers
+- rand_core 0.10.1: The Rand Project Developers
 - rustc-hash 2.1.2: The Rust Project Developers
-- savvy 0.9.2: Hiroaki Yutani
-- savvy-bindgen 0.9.2: Hiroaki Yutani
-- savvy-ffi 0.9.2: Hiroaki Yutani
-- savvy-macro 0.9.2: Hiroaki Yutani
+- savvy 0.9.4: Hiroaki Yutani
+- savvy-bindgen 0.9.4: Hiroaki Yutani
+- savvy-ffi 0.9.4: Hiroaki Yutani
+- savvy-macro 0.9.4: Hiroaki Yutani
+- semver 1.0.28: David Tolnay
+- serde 1.0.228: Erick Tryzelaar, David Tolnay
+- serde_core 1.0.228: Erick Tryzelaar, David Tolnay
+- serde_derive 1.0.228: Erick Tryzelaar, David Tolnay
+- serde_json 1.0.149: Erick Tryzelaar, David Tolnay
 - shlex 1.3.0: comex, Fenhl, Adrian Taylor, Alex Touchet, Daniel Parks, Garrett Berg
 - syn 2.0.117: David Tolnay
 - unicode-ident 1.0.24: David Tolnay
+- unicode-xid 0.2.6: erick.tryzelaar, kwantam, Manish Goregaokar
+- wasm-encoder 0.244.0: Nick Fitzgerald
+- wasmparser 0.244.0: Yury Delendik
+- wit-bindgen 0.51.0: Alex Crichton
+- wit-bindgen 0.57.1: Alex Crichton
+- wit-bindgen-core 0.51.0: Alex Crichton
+- wit-bindgen-rust 0.51.0: Alex Crichton
+- wit-bindgen-rust-macro 0.51.0: Alex Crichton
+- wit-component 0.244.0: Peter Huene
+- wit-parser 0.244.0: Alex Crichton
+- zmij 1.0.21: David Tolnay
 
-(This file was auto-generated from 'cargo metadata' on 2026-03-30)
+(This file was auto-generated from 'cargo metadata' on 2026-07-02)

--- a/rsamplr_pkg/inst/AUTHORS.md
+++ b/rsamplr_pkg/inst/AUTHORS.md
@@ -1,17 +1,13 @@
 # Authors of vendored cargo crates
 - autocfg 1.5.1: Josh Stone
 - cc 1.2.65: Alex Crichton
-- cfg-if 1.0.4: Alex Crichton
 - envisim_estimate 0.6.0: Wilmer Prentius
 - envisim_samplr 0.7.0: Wilmer Prentius
 - envisim_utils 0.6.0: Wilmer Prentius
-- getrandom 0.4.3: The Rand Project Developers
-- libc 0.2.186: The Rust Project Developers
 - num-integer 0.1.46: The Rust Project Developers
 - num-traits 0.2.19: The Rust Project Developers
 - proc-macro2 1.0.106: David Tolnay, Alex Crichton
 - quote 1.0.46: David Tolnay
-- rand 0.10.2: The Rand Project Developers, The Rust Project Developers
 - rand_core 0.10.1: The Rand Project Developers
 - rustc-hash 2.1.2: The Rust Project Developers
 - savvy 0.9.4: Hiroaki Yutani

--- a/rsamplr_pkg/justfile
+++ b/rsamplr_pkg/justfile
@@ -4,6 +4,7 @@ cargo_lock := rust_src + '/Cargo.lock'
 r_source := 'R/*'
 rust_source := rust_src + '/src/**/*.rs'
 build_path := 'build'
+vendor_path := rust_src + '/vendor'
 
 # Default to just --list
 default:
@@ -11,7 +12,7 @@ default:
 
 # Clean the environment
 clean-all:
-	rm -rf src/vendor || true
+	rm -rf {{vendor_path}} || true
 
 # Performs sanity check on code
 sanity-check: ## Perform code sanity checks if needed
@@ -29,7 +30,7 @@ build: build-wrappers build-vendor document-vendor document
     R -e 'devtools::build_manual("{{build_path}}", "{{build_path}}")'
 
 # Vendor the rust sources
-build-vendor:
+build-vendor: clean-all
   Rscript dev/vendoring.R
 
 # Update wrappers

--- a/rsamplr_pkg/src/rust/Cargo.toml
+++ b/rsamplr_pkg/src/rust/Cargo.toml
@@ -19,9 +19,6 @@ envisim_estimate = {version="*", path="../../../envisim_estimate"}
 envisim_samplr = {version="*", path="../../../envisim_samplr"}
 envisim_utils = {version="*", path="../../../envisim_utils", default-features=false}
 
-# [lints]
-# workspace = true
-
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }
 restriction = { level = "warn", priority = -2 }

--- a/rsamplr_pkg/src/rust/Cargo.toml
+++ b/rsamplr_pkg/src/rust/Cargo.toml
@@ -19,8 +19,53 @@ envisim_estimate = {version="*", path="../../../envisim_estimate"}
 envisim_samplr = {version="*", path="../../../envisim_samplr"}
 envisim_utils = {version="*", path="../../../envisim_utils", default-features=false}
 
-[lints]
-workspace = true
+# [lints]
+# workspace = true
+
+[lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+restriction = { level = "warn", priority = -2 }
+
+# suspicious
+blanket_clippy_restriction_lints = "allow"
+
+# pedantic
+
+# restriction
+arbitrary_source_item_ordering = "allow"
+arithmetic_side_effects = "allow"
+default_numeric_fallback = "allow"
+else_if_without_else = "allow"
+empty_structs_with_brackets = "allow"
+exhaustive_structs = "allow"
+expect_used = "allow"
+float_arithmetic = "allow"
+indexing_slicing = "allow"
+implicit_return = "allow"
+integer_division_remainder_used = "allow"
+iter_over_hash_type = "allow"
+min_ident_chars = "allow"
+missing_trait_methods = "allow"
+map_err_ignore = "allow"
+module_name_repetitions = "allow"
+mod_module_files = "allow"
+pattern_type_mismatch = "allow"
+pub_use = "allow"
+same_name_method = "allow"
+semicolon_inside_block = "allow"
+separated_literal_suffix = "allow"
+shadow_reuse = "allow"
+single_call_fn = "allow"
+std_instead_of_alloc = "allow"
+std_instead_of_core = "allow"
+unused_trait_names = "allow"
+unwrap_in_result = "allow"
+question_mark_used = "allow"
+
+# nursery
+equatable_if_let = "warn"
+imprecise_flops = "warn"
+needless_collect = "warn"
 
 [profile.release]
 # By default, on release build, savvy terminates the R session when a panic

--- a/rsamplr_pkg/src/rust/rust-toolchain.toml
+++ b/rsamplr_pkg/src/rust/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.85.1"

--- a/rsamplr_pkg/src/rust/rustfmt.toml
+++ b/rsamplr_pkg/src/rust/rustfmt.toml
@@ -1,0 +1,8 @@
+unstable_features = true
+edition = "2024"
+imports_layout = "Vertical"
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"
+indent_style = "Block"
+reorder_imports = true
+fn_single_line = true

--- a/rsamplr_pkg/src/rust/src/lib.rs
+++ b/rsamplr_pkg/src/rust/src/lib.rs
@@ -26,10 +26,7 @@ use envisim_samplr::dbd::DistributionalDesignEvaluators;
 use envisim_samplr::pivotal_method::hierarchical_lpm_2;
 use envisim_samplr::*;
 use envisim_utils::pips::pips_from_slice;
-use envisim_utils::sampling_options::{
-    SamplingOptions,
-    SpreadingOptions,
-};
+use envisim_utils::sampling_options::SamplingOptions;
 use savvy::{
     IntegerSexp,
     OwnedIntegerSexp,
@@ -56,9 +53,7 @@ fn rust_unequal(
 ) -> savvy::Result<Sexp> {
     let mut rng = RRng::new();
     let prob = r_prob.as_slice();
-    let options = SamplingOptions::new(prob.into())?
-        .set_eps(r_eps)?
-        .set_max_iterations(to_nzusize(r_max_iter)?)?;
+    let options = probs_to_sampling_options(prob, r_eps, r_max_iter)?;
 
     let s = match r_method {
         "spm" => options.spm(&mut rng),
@@ -88,14 +83,9 @@ fn rust_spatially_balanced(
     r_method: &str,
 ) -> savvy::Result<Sexp> {
     let mut rng = RRng::new();
+    let aux = RMatrixData::to_spreading_options(r_data, r_bucket_size)?;
     let prob = r_prob.as_slice();
-    let data = to_matrix(r_data.as_slice(), get_nrow(&r_data)?);
-
-    let bucket_size = to_usize(r_bucket_size)?;
-    let aux = SpreadingOptions::new(data).set_bucket_size(bucket_size)?;
-    let options = SamplingOptions::new(prob.into())?
-        .set_eps(r_eps)?
-        .set_spreading(aux)?;
+    let options = probs_to_sampling_options(prob, r_eps, None)?.set_spreading(aux)?;
 
     let s = match r_method {
         "lpm_1" => options.lpm_1(&mut rng),
@@ -119,19 +109,15 @@ fn rust_distributionally_balanced_design(
     r_method: &str,
 ) -> savvy::Result<Sexp> {
     let mut rng = RRng::new();
-    let population_size = get_nrow(&r_data)?;
+    let aux = RMatrixData::to_spreading_options(r_data, None)?;
     let sample_size = to_usize(r_sample_size)?;
-    let data = to_matrix(r_data.as_slice(), population_size);
     let iter = to_nzusize(r_iter)?;
 
     let dbs_options = DistributionalDesignOptions::new(r_temp)?
         .set_annealing_cooling_rate(r_cooling)?
         .set_spatial_initialization(r_spatial_init);
 
-    let aux = SpreadingOptions::new(data);
-    let options = SamplingOptions::new_equal(population_size, sample_size)?
-        .set_spreading(aux)?
-        .set_max_iterations(iter)?;
+    let options = SamplingOptions::with_spreading(aux, sample_size)?.set_max_iterations(iter)?;
 
     let s = match r_method {
         "dbd_tc" => options.dbd_tc(&mut rng, dbs_options)?.into_buckets(),
@@ -149,12 +135,9 @@ fn rust_balanced(
     r_method: &str,
 ) -> savvy::Result<Sexp> {
     let mut rng = RRng::new();
+    let bal_data = RMatrixData::to_matrix(r_bal_data)?;
     let prob = r_prob.as_slice();
-    let bal_data = to_matrix(r_bal_data.as_slice(), get_nrow(&r_bal_data)?);
-
-    let options = SamplingOptions::new(prob.into())?
-        .set_eps(r_eps)?
-        .set_balancing(bal_data)?;
+    let options = probs_to_sampling_options(prob, r_eps, None)?.set_balancing(bal_data)?;
 
     let s = match r_method {
         "sequential_cube" => options.sequential_cube(&mut rng),
@@ -174,14 +157,10 @@ fn rust_doubly_balanced(
     r_method: &str,
 ) -> savvy::Result<Sexp> {
     let mut rng = RRng::new();
+    let aux = RMatrixData::to_spreading_options(r_data, r_bucket_size)?;
+    let bal_data = RMatrixData::to_matrix(r_bal_data)?;
     let prob = r_prob.as_slice();
-    let data = to_matrix(r_data.as_slice(), get_nrow(&r_data)?);
-    let bal_data = to_matrix(r_bal_data.as_slice(), get_nrow(&r_bal_data)?);
-
-    let bucket_size = to_usize(r_bucket_size)?;
-    let aux = SpreadingOptions::new(data).set_bucket_size(bucket_size)?;
-    let options = SamplingOptions::new(prob.into())?
-        .set_eps(r_eps)?
+    let options = probs_to_sampling_options(prob, r_eps, None)?
         .set_balancing(bal_data)?
         .set_spreading(aux)?;
 
@@ -203,14 +182,9 @@ fn rust_spatially_balanced_hierarchical(
 ) -> savvy::Result<Sexp> {
     // Returns a matrix with sample indices (0) and groups (1)
     let mut rng = RRng::new();
+    let aux = RMatrixData::to_spreading_options(r_data, r_bucket_size)?;
     let prob = r_prob.as_slice();
-    let data = to_matrix(r_data.as_slice(), get_nrow(&r_data)?);
-
-    let bucket_size = to_usize(r_bucket_size)?;
-    let aux = SpreadingOptions::new(data).set_bucket_size(bucket_size)?;
-    let options = SamplingOptions::new(prob.into())?
-        .set_eps(r_eps)?
-        .set_spreading(aux)?;
+    let options = probs_to_sampling_options(prob, r_eps, None)?.set_spreading(aux)?;
 
     let sizes: Vec<usize> = r_sizes
         .iter()
@@ -246,13 +220,10 @@ fn rust_balanced_stratified(
     r_method: &str,
 ) -> savvy::Result<Sexp> {
     let mut rng = RRng::new();
-    let prob = r_prob.as_slice();
-    let bal_data = to_matrix(r_bal_data.as_slice(), get_nrow(&r_bal_data)?);
+    let bal_data = RMatrixData::to_matrix(r_bal_data)?;
     let strata: Vec<i64> = r_strata.iter().map(|&x| i64::from(x)).collect();
-
-    let options = SamplingOptions::new(prob.into())?
-        .set_eps(r_eps)?
-        .set_balancing(bal_data)?;
+    let prob = r_prob.as_slice();
+    let options = probs_to_sampling_options(prob, r_eps, None)?.set_balancing(bal_data)?;
 
     let s = match r_method {
         "cube" | &_ => cube_stratified(&mut rng, &options, &strata)?,
@@ -272,17 +243,14 @@ fn rust_doubly_balanced_stratified(
     r_method: &str,
 ) -> savvy::Result<Sexp> {
     let mut rng = RRng::new();
+    let aux = RMatrixData::to_spreading_options(r_data, r_bucket_size)?;
+    let bal_data = RMatrixData::to_matrix(r_bal_data)?;
     let prob = r_prob.as_slice();
-    let data = to_matrix(r_data.as_slice(), get_nrow(&r_data)?);
-    let bal_data = to_matrix(r_bal_data.as_slice(), get_nrow(&r_bal_data)?);
-    let strata: Vec<i64> = r_strata.iter().map(|&x| i64::from(x)).collect();
-
-    let bucket_size = to_usize(r_bucket_size)?;
-    let aux = SpreadingOptions::new(data).set_bucket_size(bucket_size)?;
-    let options = SamplingOptions::new(prob.into())?
-        .set_eps(r_eps)?
+    let options = probs_to_sampling_options(prob, r_eps, None)?
         .set_balancing(bal_data)?
         .set_spreading(aux)?;
+
+    let strata: Vec<i64> = r_strata.iter().map(|&x| i64::from(x)).collect();
 
     let s = match r_method {
         "local_cube" | &_ => local_cube_stratified(&mut rng, &options, &strata)?,
@@ -298,16 +266,13 @@ fn rust_local_mean_variance(
     r_data: RealSexp,
     r_neighbours: i32,
 ) -> savvy::Result<Sexp> {
-    if r_neighbours <= 0 {
-        return f64::NAN.try_into();
-    }
-
-    let neighbours = to_nzusize(r_neighbours)?;
+    let aux = RMatrixData::to_spreading_options(r_data, None)?;
     let prob = r_prob.as_slice();
-    let data = to_matrix(r_data.as_slice(), get_nrow(&r_data)?);
+    let options = probs_to_sampling_options(prob, None, None)?.set_spreading(aux)?;
 
-    let aux = SpreadingOptions::new(data);
-    let options = SamplingOptions::new(prob.into())?.set_spreading(aux)?;
+    let Ok(neighbours) = to_nzusize(r_neighbours) else {
+        return f64::NAN.try_into();
+    };
 
     local_mean_variance(r_values.as_slice(), &options, neighbours)?.try_into()
 }
@@ -319,15 +284,11 @@ fn rust_spatial_balance_measure(
     r_data: RealSexp,
     r_method: &str,
 ) -> savvy::Result<Sexp> {
+    let aux = RMatrixData::to_spreading_options(r_data, None)?;
     let prob = r_prob.as_slice();
-    let data = to_matrix(r_data.as_slice(), get_nrow(&r_data)?);
-    let sample: Vec<usize> = r_sample
-        .iter()
-        .map(|&x| to_usize(x - 1))
-        .collect::<savvy::Result<_>>()?;
+    let options = probs_to_sampling_options(prob, None, None)?.set_spreading(aux)?;
 
-    let aux = SpreadingOptions::new(data);
-    let options = SamplingOptions::new(prob.into())?.set_spreading(aux)?;
+    let sample = to_sample(&r_sample)?;
 
     let v = match r_method {
         "local" => options.local(&sample, true)?,
@@ -346,16 +307,11 @@ fn rust_spatial_balance_measure_equal(
     r_data: RealSexp,
     r_method: &str,
 ) -> savvy::Result<Sexp> {
-    let data = to_matrix(r_data.as_slice(), get_nrow(&r_data)?);
-    let sample: Vec<usize> = r_sample
-        .iter()
-        .map(|&x| to_usize(x - 1))
-        .collect::<savvy::Result<_>>()?;
     let sample_size = to_usize(r_sample_size)?;
-    let population_size = data.nrow();
+    let aux = RMatrixData::to_spreading_options(r_data, None)?;
+    let options = SamplingOptions::with_spreading(aux, sample_size)?;
 
-    let aux = SpreadingOptions::new(data);
-    let options = SamplingOptions::new_equal(population_size, sample_size)?.set_spreading(aux)?;
+    let sample = to_sample(&r_sample)?;
 
     let v = match r_method {
         "local" => options.local(&sample, true)?,
@@ -373,15 +329,11 @@ fn rust_balance_deviation(
     r_prob: RealSexp,
     r_data: RealSexp,
 ) -> savvy::Result<Sexp> {
+    let aux = RMatrixData::to_spreading_options(r_data, None)?;
     let prob = r_prob.as_slice();
-    let data = to_matrix(r_data.as_slice(), get_nrow(&r_data)?);
-    let sample: Vec<usize> = r_sample
-        .iter()
-        .map(|&x| to_usize(x - 1))
-        .collect::<savvy::Result<_>>()?;
+    let options = probs_to_sampling_options(prob, None, None)?.set_spreading(aux)?;
 
-    let aux = SpreadingOptions::new(data);
-    let options = SamplingOptions::new(prob.into())?.set_spreading(aux)?;
+    let sample = to_sample(&r_sample)?;
 
     balance_deviation_spreading(&sample, &options)?.try_into()
 }
@@ -398,15 +350,11 @@ fn rust_spatial_balance_measure_all(
     r_prob: RealSexp,
     r_data: RealSexp,
 ) -> savvy::Result<Sexp> {
+    let aux = RMatrixData::to_spreading_options(r_data, None)?;
     let prob = r_prob.as_slice();
-    let data = to_matrix(r_data.as_slice(), get_nrow(&r_data)?);
-    let sample: Vec<usize> = r_sample
-        .iter()
-        .map(|&x| to_usize(x - 1))
-        .collect::<savvy::Result<_>>()?;
+    let options = probs_to_sampling_options(prob, None, None)?.set_spreading(aux)?;
 
-    let aux = SpreadingOptions::new(data);
-    let options = SamplingOptions::new(prob.into())?.set_spreading(aux)?;
+    let sample = to_sample(&r_sample)?;
 
     let bms = vec![
         options.voronoi(&sample)?,
@@ -424,16 +372,11 @@ fn rust_spatial_balance_measure_all_equal(
     r_sample_size: i32,
     r_data: RealSexp,
 ) -> savvy::Result<Sexp> {
-    let data = to_matrix(r_data.as_slice(), get_nrow(&r_data)?);
-    let sample: Vec<usize> = r_sample
-        .iter()
-        .map(|&x| to_usize(x - 1))
-        .collect::<savvy::Result<_>>()?;
     let sample_size = to_usize(r_sample_size)?;
-    let population_size = data.nrow();
+    let aux = RMatrixData::to_spreading_options(r_data, None)?;
+    let options = SamplingOptions::with_spreading(aux, sample_size)?;
 
-    let aux = SpreadingOptions::new(data);
-    let options = SamplingOptions::new_equal(population_size, sample_size)?.set_spreading(aux)?;
+    let sample = to_sample(&r_sample)?;
 
     let bms = vec![
         options.voronoi(&sample)?,
@@ -457,9 +400,9 @@ fn rust_distributionally_balanced_design_iter(
     r_method: &str,
 ) -> savvy::Result<Sexp> {
     let mut rng = RRng::new();
-    let population_size = get_nrow(&r_data)?;
+    let aux = RMatrixData::to_spreading_options(r_data, None)?;
     let sample_size = to_usize(r_sample_size)?;
-    let data = to_matrix(r_data.as_slice(), population_size);
+
     let iter_to = to_nzusize(r_iter_to)?;
     let iter_by = to_nzusize(r_iter_by)?;
 
@@ -467,8 +410,7 @@ fn rust_distributionally_balanced_design_iter(
         .set_annealing_cooling_rate(r_cooling)?
         .set_spatial_initialization(r_spatial_init);
 
-    let aux = SpreadingOptions::new(data);
-    let options = SamplingOptions::new_equal(population_size, sample_size)?.set_spreading(aux)?;
+    let options = SamplingOptions::with_spreading(aux, sample_size)?;
 
     let s = match r_method {
         "dbd_tc" => options.dbd_tc_evaluator(&mut rng, dbs_options, iter_to, iter_by),

--- a/rsamplr_pkg/src/rust/src/matrix.rs
+++ b/rsamplr_pkg/src/rust/src/matrix.rs
@@ -12,30 +12,59 @@
 
 //! Matrix utils
 
-use std::num::NonZeroUsize;
-
-pub use envisim_utils::matrix::Dimensions;
-use envisim_utils::matrix::MatrixRef;
+use envisim_samplr::SpreadingOptions;
+use envisim_utils::matrix::{
+    MatrixBase,
+    RawData,
+};
 use savvy::{
     RealSexp,
     savvy_err,
 };
 
-/// Returns the nrow attribute from a [`RealSexp`].
-/// # Panics
-/// Panics if Sexp is not a matrix, or the dimension is 0
-#[inline]
-pub fn get_nrow(mat: &RealSexp) -> savvy::Result<NonZeroUsize> {
-    let rows: usize = mat.get_dim().ok_or(savvy_err!("object is not matrix"))?[0]
-        .try_into()
-        .map_err(|_| savvy_err!("dimension must be positive"))?;
-    NonZeroUsize::new(rows).ok_or(savvy_err!("dimension must be positive"))
-}
+use crate::utils::{
+    to_nzusize,
+    to_usize,
+};
 
-/// Converts into a matrix
-/// # Panics
-/// Panics if the dimensions are invalid
-#[inline]
-pub fn to_matrix(mat: &[f64], nrow: NonZeroUsize) -> MatrixRef<'_, f64> {
-    MatrixRef::new(mat, nrow).expect("matrix to have valid dimensions")
+/// Wrapper for matrix data
+pub struct RMatrixData(RealSexp);
+/// Type alias for `Matrix` using
+pub type RMatrix = MatrixBase<RMatrixData>;
+impl RawData for RMatrixData {
+    type Elem = f64;
+    #[inline]
+    fn data(&self) -> &[Self::Elem] { self.0.as_slice() }
+}
+impl RMatrixData {
+    /// Constructs a `RMatrix` from `RealSexp`
+    #[inline]
+    pub fn to_matrix(sexp: RealSexp) -> savvy::Result<RMatrix> {
+        let rows = match sexp
+            .get_dim()
+            .ok_or_else(|| savvy_err!("object have no dimensions"))?
+        {
+            [_, _, _, ..] => Err(savvy_err!("object have too many dimensions")),
+            [r, ..] => to_usize(*r),
+            _ => Err(savvy_err!("object have no dimensions")),
+        }?;
+        Ok(MatrixBase::new(RMatrixData(sexp), rows).expect("rows to be NonZeroUsize"))
+    }
+    /// Constructs spreading options from `RealSexp`
+    #[inline]
+    pub fn to_spreading_options<BSZ>(
+        sexp: RealSexp,
+        bucket_size: BSZ,
+    ) -> savvy::Result<SpreadingOptions<RMatrix>>
+    where
+        BSZ: Into<Option<i32>>,
+    {
+        let data = Self::to_matrix(sexp)?;
+        let mut opts = SpreadingOptions::new(data);
+        if let Some(bucket_size) = bucket_size.into() {
+            let bucket_size = to_nzusize(bucket_size)?;
+            opts = opts.set_bucket_size(bucket_size)?;
+        }
+        Ok(opts)
+    }
 }

--- a/rsamplr_pkg/src/rust/src/utils.rs
+++ b/rsamplr_pkg/src/rust/src/utils.rs
@@ -14,8 +14,13 @@
 
 use std::num::NonZeroUsize;
 
+use envisim_samplr::{
+    SamplingOptions,
+    UnequalProbabilityOptions,
+};
 use num_traits::ToPrimitive;
 use savvy::{
+    IntegerSexp,
     OwnedIntegerSexp,
     Sexp,
     savvy_err,
@@ -74,4 +79,33 @@ pub fn return_sample(sample: Vec<usize>) -> savvy::Result<Sexp> {
     }
 
     Ok(Sexp::from(out))
+}
+
+/// Converts an 1-indexed sample from R (`IntegerSexp`) to a 0-indexed `Vec`.
+/// # Errors
+/// If any element cannot be converted to `usize`.
+pub fn to_sample(rsample: &IntegerSexp) -> savvy::Result<Vec<usize>> {
+    rsample.iter().map(|&x| to_usize(x - 1)).collect()
+}
+
+/// Constructs sampling options
+pub fn probs_to_sampling_options<EPS, MAX>(
+    prob: &[f64],
+    eps: EPS,
+    max_iter: MAX,
+) -> savvy::Result<SamplingOptions<UnequalProbabilityOptions<'_, f64>, (), ()>>
+where
+    EPS: Into<Option<f64>>,
+    MAX: Into<Option<i32>>,
+{
+    // let prob = prob.as_slice();
+    let mut opts = SamplingOptions::new(prob.into())?;
+    if let Some(eps) = eps.into() {
+        opts = opts.set_eps(eps)?;
+    }
+    if let Some(max_iter) = max_iter.into() {
+        let max_iter = to_nzusize(max_iter)?;
+        opts = opts.set_max_iterations(max_iter)?;
+    }
+    Ok(opts)
 }


### PR DESCRIPTION
By removing the intermediate storage levels `BorrowedData` and `OwnedMatrixData`, instead introducing a new trait `RawDataMut`, we make it easier to implement other stores for holding `Matrix` data (such as, say `RealSexp`).

The rpkg now can operate directly on the RealSexp, and doesnt need to go through the slice.

Additionally, the rpkg need to be removed from workspace, as it need its own lockfile.

## envisim_utils
### Added
- Methods `SamplingOptions::with_spreading` and `with_balancing` for equal probability sampling, setting the population size from the provided data.

### Changed
- Matrix storage: Removed `OwnedMatrixData`, `BorrowedMatrixData` and added `RawDataMut`. Implemented `RawData` and `RawDataMut` for array-like types in `std`.

### Removed
- Removed second (ergonomic) generic for data type in `Matrix`. Defaulted to `RawData::Elem`, now derived from the same.