### PR TITLE
(feat) Use matrix in DBD TC

### DIFF
--- a/envisim_samplr/CHANGELOG.md
+++ b/envisim_samplr/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- `dbd_tc` use `Matrix` to store buckets.
 
 ## [0.6.0] - 2026-06-02
 - Bumped dependency `envisim_utils`.

--- a/envisim_samplr/src/dbd/dbd_circular.rs
+++ b/envisim_samplr/src/dbd/dbd_circular.rs
@@ -45,7 +45,7 @@ mod config {
     #[derive(Clone, Debug)]
     pub struct CircularConfiguration {
         /// Internal storage of sequence
-        sequence: Vec<usize>,
+        sequence: Box<[usize]>,
         /// Total energy multiplied by sample size
         total_nenergy: f64,
         /// Tactical configuration parameters
@@ -58,7 +58,7 @@ mod config {
         /// Panics if the sequence is empty.
         #[inline]
         pub fn new<P>(
-            sequence: Vec<usize>,
+            sequence: Box<[usize]>,
             sample_size: NonZeroUsize,
             ed: &EnergyDistance<P>,
         ) -> Self
@@ -90,7 +90,7 @@ mod config {
         /// Consumes `self` and returns the internal storage
         #[must_use]
         #[inline]
-        pub fn into_sequence(self) -> Vec<usize> { self.sequence }
+        pub fn into_sequence(self) -> Box<[usize]> { self.sequence }
         /// Returns a mutable reference to the sequence store
         #[must_use]
         #[inline]
@@ -180,6 +180,10 @@ impl<P> DbdCircular<P> {
     ///
     /// # Errors
     /// Returns the full configuration in case of `sample_size` equaling the population size.
+    #[expect(
+        clippy::unreachable,
+        reason = "matrix has rows > 0, one unit must exist in sequence"
+    )]
     #[inline]
     pub fn new(
         dbs_options: &DistributionalDesignOptions,
@@ -190,11 +194,15 @@ impl<P> DbdCircular<P> {
     where
         P: PointSet<Id = usize, Value = f64>,
     {
-        let sequence: Vec<usize> = matrix.ids().collect();
+        let sequence: Box<[usize]> = matrix.ids().collect();
         let annealing_temperature = dbs_options.as_annealing_temperature(eps);
         let ed = EnergyDistance::new(matrix, sample_size);
 
-        let pair = (sequence[0], sequence[1]);
+        let pair = match sequence.as_ref() {
+            [a, b, ..] => (*a, *b),
+            [a] => (*a, *a),
+            _ => unreachable!("empty sequence"),
+        };
         let configuration = CircularConfiguration::new(sequence, sample_size, &ed);
 
         if configuration.tcp().n_samples().get() <= 1 {

--- a/envisim_samplr/src/dbd/dbd_tc.rs
+++ b/envisim_samplr/src/dbd/dbd_tc.rs
@@ -12,6 +12,7 @@
 
 //! Distributionally balanced designs using tactical configurations
 
+use std::iter::repeat_n;
 use std::num::NonZeroUsize;
 
 pub use config::*;
@@ -37,6 +38,10 @@ use crate::utils::shuffled_indices;
 mod config {
     //! Tactical configuration DBD config
 
+    use envisim_utils::matrix::{
+        Dimensions,
+        MatrixBase,
+    };
     use envisim_utils::spatial::PointSet;
 
     use crate::dbd::energy_distance::EnergyDistance;
@@ -45,12 +50,15 @@ mod config {
         TacticalConfigurationParameters,
     };
 
+    /// Storage for the buckets used in a Tactical Configuration
+    pub type TcBuckets = MatrixBase<Box<[usize]>>;
+
     #[must_use]
     #[derive(Clone, Debug)]
     pub struct TacticalConfiguration {
         /// Internal storage of sequence (`sample_size` * `n_samples` matrix)
         // An n * M matrix
-        buckets: Vec<usize>,
+        buckets: TcBuckets,
         /// Total energy multiplied by sample size
         total_nenergy: f64,
         /// Tactical configuration parameters
@@ -65,7 +73,7 @@ mod config {
         /// `n_samples * sample_size`.
         #[inline]
         pub fn new<P>(
-            sequence: Vec<usize>,
+            buckets: TcBuckets,
             tcp: TacticalConfigurationParameters,
             ed: &EnergyDistance<P>,
         ) -> Self
@@ -73,13 +81,13 @@ mod config {
             P: PointSet<Id = usize, Value = f64>,
         {
             assert_eq!(
-                sequence.len(),
-                tcp.n_samples().get() * tcp.sample_size().get(),
+                buckets.dims(),
+                (tcp.sample_size(), tcp.n_samples()).into(),
                 "invalid sequence length"
             );
 
             let mut cc = Self {
-                buckets: sequence,
+                buckets,
                 total_nenergy: 0.0,
                 tcp,
             };
@@ -88,37 +96,14 @@ mod config {
             cc
         }
         /// Returns a reference to the internal storage
-        #[must_use]
         #[inline]
-        pub fn buckets(&self) -> &[usize] { &self.buckets }
+        pub fn buckets(&self) -> &TcBuckets { &self.buckets }
         /// Consumes `self` and returns the internal storage
-        #[must_use]
         #[inline]
-        pub fn into_buckets(self) -> Vec<usize> { self.buckets }
+        pub fn into_buckets(self) -> TcBuckets { self.buckets }
         /// Returns a mutable reference to the internal storage
-        #[must_use]
         #[inline]
-        pub fn buckets_mut(&mut self) -> &mut [usize] { &mut self.buckets }
-        /// Returns the element at position `k` from a sample `sample_id`
-        #[must_use]
-        #[inline]
-        pub fn bucket_get(&self, sample_id: usize, k: usize) -> Option<usize> {
-            self.buckets.get(self.index(sample_id, k)).copied()
-        }
-        /// Returns the internal index of an element at position `k` in sample `sample_id`
-        ///
-        /// # Panics
-        /// Panics if `sample_id` or `k` is oob.
-        #[must_use]
-        #[inline]
-        pub(crate) fn index(&self, sample_id: usize, k: usize) -> usize {
-            assert!(sample_id < self.tcp.n_samples().get(), "invalid sample_id");
-            assert!(
-                k < self.tcp.sample_size().get(),
-                "invalid sample unit index"
-            );
-            sample_id * self.tcp.sample_size().get() + k
-        }
+        pub fn buckets_mut(&mut self) -> &mut TcBuckets { &mut self.buckets }
         /// Add a delta to the nenergy
         #[must_use]
         #[inline]
@@ -149,11 +134,9 @@ mod config {
         /// Panics if `sample_id` is oob.
         #[inline]
         fn sample(&self, sample_id: usize) -> impl Iterator<Item = usize> + Clone + '_ {
-            assert!(sample_id < self.tcp.n_samples().get(), "invalid sample_id");
             self.buckets
-                .iter()
-                .skip(sample_id * self.tcp.sample_size().get())
-                .take(self.tcp.sample_size().get())
+                .col_iter(sample_id)
+                .expect("valid sample id")
                 .copied()
         }
     }
@@ -224,12 +207,12 @@ impl<P> DbdTacticalConfiguration<P> {
         let sample_size = sample_size.min(population_size);
         let tcp = TacticalConfigurationParameters::new_minimal(population_size, sample_size);
 
-        let sequence = if dbs_options.spatial_initialization() {
+        let mut buckets = TcBuckets::from_value(0, (sample_size, tcp.n_samples()));
+
+        if dbs_options.spatial_initialization() {
             // Initial budget
             let mut b = vec![tcp.n_repeats().get(); tcp.population_size().get()];
             // Offset to samples
-            let mut offset = 0;
-            let mut samples: Vec<usize> = vec![0; sample_size.get() * tcp.n_samples().get()];
 
             for k in 0..tcp.n_samples().get() {
                 // Construct lpm opts
@@ -250,35 +233,35 @@ impl<P> DbdTacticalConfiguration<P> {
                 );
 
                 // For each unit in the sample, reduce the budget
-                for (i, &id) in s.iter().enumerate() {
-                    samples[offset + i] = id;
+                for (c, id) in buckets
+                    .col_iter_mut(k)
+                    .expect("column to exist")
+                    .zip(s.into_iter())
+                {
+                    *c = id;
                     b[id] -= 1;
                 }
-
-                offset += tcp.sample_size().get();
             }
-
-            samples
         } else {
             // Add random sequence in next version
-            let sequence = shuffled_indices(rng, tcp.population_size());
-            let mut samples: Vec<usize> = vec![0; sample_size.get() * tcp.n_samples().get()];
-            let mut i: usize = 0;
-            for &id in &sequence {
-                for _ in 0..tcp.n_repeats().get() {
-                    samples[(i % tcp.n_samples()) * sample_size.get() + i / tcp.n_samples()] = id;
-                    i += 1;
+            let initial_sequence = shuffled_indices(rng, tcp.population_size());
+            // Iterate over ther sequence, repeating each element n_repeats times
+            let mut sequence_iter = initial_sequence
+                .into_iter()
+                .flat_map(|id| repeat_n(id, tcp.n_repeats().get()));
+            // Iterate over the matrix row-wise
+            for row in 0..sample_size.get() {
+                for c in buckets.row_iter_mut(row).expect("row to exist") {
+                    *c = sequence_iter.next().expect("sequence to have a unit");
                 }
             }
-
-            samples
         };
 
         let annealing_temperature = dbs_options.as_annealing_temperature(eps);
         let ed = EnergyDistance::new(matrix, sample_size);
 
         let pair = ((0, 0), (1, 0));
-        let configuration = TacticalConfiguration::new(sequence, tcp, &ed);
+        let configuration = TacticalConfiguration::new(buckets, tcp, &ed);
 
         if configuration.tcp().n_samples().get() <= 1 {
             return Err(configuration);
@@ -322,8 +305,16 @@ where
                 b_unit.0 = n_samples - 1;
             }
 
-            let a_id = self.configuration.bucket_get(a_unit.0, a_unit.1);
-            let b_id = self.configuration.bucket_get(b_unit.0, b_unit.1);
+            let a_id = self
+                .configuration
+                .buckets()
+                .get((a_unit.1, a_unit.0))
+                .copied();
+            let b_id = self
+                .configuration
+                .buckets()
+                .get((b_unit.1, b_unit.0))
+                .copied();
             if a_id != b_id {
                 self.pair = (a_unit, b_unit);
                 self.total_nenergy_delta = None;
@@ -336,13 +327,15 @@ where
         self.total_nenergy_delta = None;
 
         let ((gr1, k1), (gr2, k2)) = self.pair;
-        let id1 = self
+        let id1 = *self
             .configuration
-            .bucket_get(gr1, k1)
+            .buckets()
+            .get((k1, gr1))
             .expect("first unit to be valid");
-        let id2 = self
+        let id2 = *self
             .configuration
-            .bucket_get(gr2, k2)
+            .buckets()
+            .get((k2, gr2))
             .expect("second unit to be valid");
 
         let delta = self.ed.delta(self.configuration.sample(gr1), id2, id1)?
@@ -357,9 +350,10 @@ where
             return;
         };
 
-        let k1 = self.configuration.index(self.pair.0.0, self.pair.0.1);
-        let k2 = self.configuration.index(self.pair.1.0, self.pair.1.1);
-        self.configuration.buckets_mut().swap(k1, k2);
+        self.configuration.buckets_mut().swap(
+            (self.pair.0.1, self.pair.0.0),
+            (self.pair.1.1, self.pair.1.0),
+        );
         let _total_energy = self.configuration.add_nenergy_delta(delta);
     }
 

--- a/envisim_utils/CHANGELOG.md
+++ b/envisim_utils/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Renamed methods in `PointSet`. Use prefix `get_` rather than `try_`, renamed `exists` to `contains`, `size` to `len`, `dim` to `dimensions`, `id_iter` to `ids`. Added methods `coords` and `get_coords`, returning an iterator over an id.
 - For searchers in `kd_tree::searcher`, renamed `from_slice`, `set_from_slice`, `reset_from_slice` to `_point`. These methods now accepts iterators instead of slices.
+- Matrix storage: Removed `OwnedMatrixData`, `BorrowedMatrixData` and added `RawDataMut`. Implemented `RawData` and `RawDataMut` for array-like types in `std`.
 
+### Removed
+- Removed second (ergonomic) generic for data type in `Matrix`. Defaulted to `RawData::Elem`, now derived from the same.
 
 ## [0.6.0] - 2026-06-02
 ### Changed

--- a/envisim_utils/CHANGELOG.md
+++ b/envisim_utils/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added `Matrix::swap`, for swapping two elements in a `Matrix`.
+
 ### Changed
 - Renamed methods in `PointSet`. Use prefix `get_` rather than `try_`, renamed `exists` to `contains`, `size` to `len`, `dim` to `dimensions`, `id_iter` to `ids`. Added methods `coords` and `get_coords`, returning an iterator over an id.
 - For searchers in `kd_tree::searcher`, renamed `from_slice`, `set_from_slice`, `reset_from_slice` to `_point`. These methods now accepts iterators instead of slices.

--- a/envisim_utils/src/matrix/mod.rs
+++ b/envisim_utils/src/matrix/mod.rs
@@ -29,11 +29,14 @@ pub use dims::{
     MatrixCoord,
     MatrixDims,
 };
-use num_traits::Float;
+use num_traits::{
+    ConstOne,
+    ConstZero,
+    Float,
+};
 pub use raw_data::{
-    BorrowedMatrixData,
-    OwnedMatrixData,
     RawData,
+    RawDataMut,
 };
 
 use crate::number_traits::{
@@ -46,10 +49,7 @@ pub use crate::spatial::PointSet;
 /// Base matrix representation
 #[must_use]
 #[derive(Debug, Clone)]
-pub struct MatrixBase<T, N = <T as RawData>::Elem>
-where
-    T: RawData<Elem = N>,
-{
+pub struct MatrixBase<T> {
     /// Data
     data: T,
     /// Matrix dimension
@@ -57,30 +57,43 @@ where
 }
 
 /// Owned matrix representation
-pub type Matrix<N> = MatrixBase<OwnedMatrixData<N>>;
+pub type Matrix<N> = MatrixBase<Vec<N>>;
 /// Borrowed matrix representation
-pub type MatrixRef<'bdata, N> = MatrixBase<BorrowedMatrixData<'bdata, N>>;
+pub type MatrixRef<'bdata, N> = MatrixBase<&'bdata [N]>;
 
-impl<T, N> MatrixBase<T, N>
-where
-    T: RawData<Elem = N>,
-{
+impl<T> MatrixBase<T> {
+    /// Constructs a new owned matrix representation from some data vector.
+    /// Returns `None` if the rows are not a divisor of the data length.
+    #[inline]
+    pub fn new<NZ>(data: T, rows: NZ) -> Option<Self>
+    where
+        T: RawData,
+        NZ: TryInto<NonZeroUsize>,
+    {
+        let rows = rows.try_into().ok()?;
+        let dims = MatrixDims::from_row_count(data.data().len(), rows)?;
+        Some(Self { data, dims })
+    }
     /// Constructs a borrowed matrix representation from a matrix.
     #[inline]
-    pub fn to_matrixref(&self) -> MatrixRef<'_, N> {
+    pub fn to_matrixref(&self) -> MatrixRef<'_, T::Elem>
+    where
+        T: RawData,
+    {
         MatrixRef {
-            data: self.internal_data().into(),
+            data: self.data.data(),
             dims: self.dims(),
         }
     }
     /// Constructs an owned matrix representation from a matrix. Copies the data.
     #[inline]
-    pub fn to_matrix(&self) -> Matrix<N>
+    pub fn to_matrix(&self) -> Matrix<T::Elem>
     where
-        N: Copy,
+        T: RawData,
+        T::Elem: Copy,
     {
         Matrix {
-            data: self.internal_data().to_vec().into(),
+            data: self.data.data().to_vec(),
             dims: self.dims(),
         }
     }
@@ -88,60 +101,108 @@ where
     #[must_use]
     #[inline]
     pub fn data(&self) -> &T { &self.data }
-    /// Returns a reference to the underlying data as a slice.
-    #[must_use]
-    #[inline]
-    fn internal_data(&self) -> &[N] { self.data().data() }
     /// Returns the element at a specific coordinate.
     /// Returns `None`  if the coordinates are invalid.
     #[must_use]
     #[inline]
-    pub fn get<C>(&self, coord: C) -> Option<&N>
+    pub fn get<C>(&self, coord: C) -> Option<&T::Elem>
     where
+        T: RawData,
         C: Into<MatrixCoord>,
-        N: Copy,
     {
         let coord = coord.into();
         self.dims.contains(coord).then(|| &self[coord])
+    }
+    /// Returns a mutable reference to the element at a specific coordinate.
+    /// Returns `None`  if the coordinates are invalid.
+    #[must_use]
+    #[inline]
+    pub fn get_mut<C>(&mut self, coord: C) -> Option<&mut T::Elem>
+    where
+        T: RawDataMut,
+        C: Into<MatrixCoord>,
+    {
+        let coord = coord.into();
+        self.dims.contains(coord).then(|| &mut self[coord])
     }
     /// Returns an iterator of the elements in a row.
     /// Returns `None` if the row is invalid.
     #[must_use]
     #[inline]
-    pub fn row_iter(&self, row: usize) -> Option<impl ExactSizeIterator<Item = &N>> {
+    pub fn row_iter(&self, row: usize) -> Option<impl ExactSizeIterator<Item = &T::Elem>>
+    where
+        T: RawData,
+    {
         let nrow = self.nrow().get();
         self.dims()
             .contains_row(row)
-            .then(|| self.internal_data()[row..].iter().step_by(nrow))
+            .then(|| self.data.data()[row..].iter().step_by(nrow))
+    }
+    /// Returns a mutable iterator of the elements in a row.
+    /// Returns `None` if the row is invalid.
+    #[must_use]
+    #[inline]
+    pub fn row_iter_mut(
+        &mut self,
+        row: usize,
+    ) -> Option<impl ExactSizeIterator<Item = &mut T::Elem>>
+    where
+        T: RawDataMut,
+    {
+        let nrow = self.nrow().get();
+        self.dims()
+            .contains_row(row)
+            .then(|| self.data.data_mut()[row..].iter_mut().step_by(nrow))
     }
     /// Returns an iterator of the elements in a column.
     /// Returns `None` if the column is invalid.
     #[must_use]
     #[inline]
-    pub fn col_iter(&self, col: usize) -> Option<impl ExactSizeIterator<Item = &N>> {
+    pub fn col_iter(&self, col: usize) -> Option<impl ExactSizeIterator<Item = &T::Elem>>
+    where
+        T: RawData,
+    {
         let nrow = self.nrow().get();
         let start = nrow * col;
         self.dims()
             .contains_col(col)
-            .then(|| self.internal_data()[start..(start + nrow)].iter())
+            .then(|| self.data.data()[start..(start + nrow)].iter())
+    }
+    /// Returns a mutable iterator of the elements in a column.
+    /// Returns `None` if the column is invalid.
+    #[must_use]
+    #[inline]
+    pub fn col_iter_mut(
+        &mut self,
+        col: usize,
+    ) -> Option<impl ExactSizeIterator<Item = &mut T::Elem>>
+    where
+        T: RawDataMut,
+    {
+        let nrow = self.nrow().get();
+        let start = nrow * col;
+        self.dims()
+            .contains_col(col)
+            .then(|| self.data.data_mut()[start..(start + nrow)].iter_mut())
     }
     /// Multiplies the matrix by a column vector.
     /// Returns `None` if the column vector length does not match the number of columns in the
     /// matrix.
     #[must_use]
     #[inline]
-    pub fn mul_vec(&self, rhs: &[N]) -> Option<Matrix<N>>
+    pub fn mul_vec(&self, rhs: &[T::Elem]) -> Option<Matrix<T::Elem>>
     where
-        N: Number,
+        T: RawData,
+        T::Elem: Number,
     {
         if self.ncol().get() != rhs.len() {
             return None;
         }
-        let mut product = vec![N::zero(); self.nrow().get()];
+        let mut product = vec![T::Elem::ZERO; self.nrow().get()];
         let mut index = 0;
         for mul in rhs {
             for pr in &mut product {
-                *pr += *mul * self.internal_data()[index];
+                *pr += *mul * self.data.data()[index];
                 index += 1;
             }
         }
@@ -152,126 +213,135 @@ where
     /// other matrix.
     #[must_use]
     #[inline]
-    pub fn mul_mat<T2>(&self, rhs: &MatrixBase<T2, N>) -> Option<Matrix<N>>
+    pub fn mul_mat<T2>(&self, rhs: &MatrixBase<T2>) -> Option<Matrix<T::Elem>>
     where
-        T2: RawData<Elem = N>,
-        N: Number,
+        T: RawData,
+        T::Elem: Number,
+        T2: RawData<Elem = T::Elem>,
     {
         if self.ncol() != rhs.nrow() {
             return None;
         }
-        let mut product = Vec::<N>::with_capacity(self.nrow().get() * rhs.ncol().get());
+        let mut product = Vec::<T::Elem>::with_capacity(self.nrow().get() * rhs.ncol().get());
         let mut index = 0;
         // Multiply self by each column in rhs
         for _ in 0..rhs.ncol().get() {
             // Take rhs column
-            let rhs_col = &rhs.internal_data()[index..(index + rhs.nrow().get())];
+            let rhs_col = &rhs.data.data()[index..(index + rhs.nrow().get())];
             // Result
             let temp_column_res = self.mul_vec(rhs_col)?;
-            product.extend_from_slice(temp_column_res.internal_data());
+            product.extend_from_slice(temp_column_res.data.data());
             index += rhs.nrow().get();
         }
         Matrix::new(product, self.nrow())
     }
-}
+    /// Calculates the inverse of `self` using LU decomposition.
+    ///
+    /// Returns `None` if `self` isn't square, or if `self` is not invertible (as defined by `eps`).
+    #[expect(clippy::many_single_char_names, reason = "only within small scope")]
+    #[must_use]
+    #[inline]
+    pub fn inverse<E>(&self, eps: E) -> Option<Matrix<T::Elem>>
+    where
+        T: RawData,
+        T::Elem: NumberFloat,
+        E: TryInto<Epsilon<T::Elem>>,
+    {
+        // Non-square
+        if !self.dims().is_square() {
+            return None;
+        }
+        let eps = eps.try_into().ok()?;
+        let nrow = self.nrow().get();
 
-impl<N> Matrix<N> {
-    /// Constructs a new owned matrix representation from some data vector.
-    /// Returns `None` if the rows are not a divisor of the data length.
-    #[inline]
-    pub fn new<NZ>(data: Vec<N>, rows: NZ) -> Option<Self>
-    where
-        NZ: TryInto<NonZeroUsize>,
-    {
-        let rows = rows.try_into().ok()?;
-        let dims = MatrixDims::from_row_count(data.len(), rows)?;
-        let data = OwnedMatrixData::new(data);
-        Some(Self { data, dims })
-    }
-    /// Constructs a new owned matrix representation filled with some value `data`.
-    #[inline]
-    pub fn from_value<D>(data: N, dims: D) -> Self
-    where
-        N: Copy,
-        D: Into<MatrixDims>,
-    {
-        let dims: MatrixDims = dims.into();
-        Self {
-            data: OwnedMatrixData::new(vec![data; dims.len().get()]),
-            dims,
+        if nrow == 2 {
+            const NZ2: NonZeroUsize = NonZeroUsize::new(2).expect("2 > 0");
+            // ab cd => 02 13
+            #[expect(clippy::unreachable, reason = "panic implies bug")]
+            let &[a, c, b, d] = self.data.data() else {
+                unreachable!("2x2 = 4")
+            };
+            // ad-bc
+            let det = a * d - b * c;
+            if eps.is_zero(det) {
+                return None;
+            };
+            // d -c -b a
+            let inv = vec![d / det, -c / det, -b / det, a / det];
+            return MatrixBase::new(inv, NZ2);
+        } else if nrow == 3 {
+            const NZ3: NonZeroUsize = NonZeroUsize::new(3).expect("3 > 0");
+            // abc def ghi => 036 147 258
+            #[expect(clippy::unreachable, reason = "panic implies bug")]
+            let &[a, d, g, b, e, h, c, f, i] = self.data.data() else {
+                unreachable!("3x3=9")
+            };
+            let mut inv = vec![
+                e * i - f * h,
+                -(d * i - f * g),
+                d * h - e * g, // ABC
+                -(b * i - c * h),
+                a * i - c * g,
+                -(a * h - b * g), // DEF
+                b * f - c * e,
+                -(a * f - c * d),
+                a * e - b * d, // GHI
+            ];
+            let det = a * inv[0] + b * inv[1] + c * inv[2]; // aA + bB +cC
+            if eps.is_zero(det) {
+                return None;
+            };
+            for v in &mut inv {
+                *v /= det;
+            }
+            return MatrixBase::new(inv, NZ3);
         }
-    }
-    /// Constructs a new identity matrix
-    #[inline]
-    pub fn new_identity<NZ>(rows: NZ) -> Option<Self>
-    where
-        N: Number,
-        NZ: TryInto<NonZeroUsize>,
-    {
-        let rows = rows.try_into().ok()?;
-        let dims = MatrixDims::new(rows, rows);
-        let mut m = Self::from_value(N::ZERO, dims);
-        for r in 0..rows.get() {
-            m[(r, r)] = N::ONE;
+
+        let (lu, p) = {
+            let mut lu = self.to_matrix();
+            let p = lu.lu_decomposition(eps)?;
+            (lu, p)
+        };
+
+        let mut inv = MatrixBase::from_value(T::Elem::ZERO, self.dims());
+
+        // Solve for each column of the identity mat
+        for col in 0..nrow {
+            // Solve LY = P
+            for row in 0..nrow {
+                let mut sum = if p[row] == col {
+                    T::Elem::ONE
+                } else {
+                    T::Elem::ZERO
+                };
+                for k in 0..row {
+                    sum -= lu[(row, k)] * inv[(k, col)];
+                }
+                inv[(row, col)] = sum;
+            }
+
+            // Solve UX =  Y for X
+            for row in (0..nrow).rev() {
+                let mut sum = inv[(row, col)];
+                for k in (row + 1)..nrow {
+                    sum -= lu[(row, k)] * inv[(k, col)];
+                }
+                inv[(row, col)] = sum / lu[(row, row)];
+            }
         }
-        Some(m)
-    }
-    /// Returns a mutable reference to the element at a specific coordinate.
-    /// Returns `None`  if the coordinates are invalid.
-    #[must_use]
-    #[inline]
-    pub fn get_mut<C>(&mut self, coord: C) -> Option<&mut N>
-    where
-        C: Into<MatrixCoord>,
-    {
-        let coord = coord.into();
-        self.dims.contains(coord).then(|| &mut self[coord])
-    }
-    /// Returns a mutable iterator of the elements in a row.
-    /// Returns `None` if the row is invalid.
-    #[must_use]
-    #[inline]
-    pub fn row_iter_mut(&mut self, row: usize) -> Option<impl ExactSizeIterator<Item = &mut N>> {
-        let nrow = self.nrow().get();
-        self.dims()
-            .contains_row(row)
-            .then(|| self.data.data[row..].iter_mut().step_by(nrow))
-    }
-    /// Returns a mutable iterator of the elements in a column.
-    /// Returns `None` if the column is invalid.
-    #[must_use]
-    #[inline]
-    pub fn col_iter_mut(&mut self, col: usize) -> Option<impl ExactSizeIterator<Item = &mut N>> {
-        let nrow = self.nrow().get();
-        let start = nrow * col;
-        self.dims()
-            .contains_col(col)
-            .then(|| self.data.data[start..(start + nrow)].iter_mut())
-    }
-    /// Resizes the matrix.
-    /// Does not respect data on expansion.
-    #[inline]
-    pub fn resize<D>(&mut self, dims: D)
-    where
-        N: Copy + num_traits::Zero,
-        D: Into<MatrixDims>,
-    {
-        let dims: MatrixDims = dims.into();
-        if dims == self.dims() {
-            return;
-        }
-        self.data.data.resize(dims.len().get(), N::zero());
-        self.dims = dims;
+
+        Some(inv)
     }
     /// Calculates the reduced row echelon form of the matrix, in place.
     #[inline]
     pub fn reduced_row_echelon_form(&mut self)
     where
-        N: NumberFloat,
+        T: RawDataMut,
+        T::Elem: NumberFloat,
     {
         let dims = self.dims();
         let index = |row, col| row + col * dims.rows.get();
-        let data = &mut self.data.data;
+        let data = self.data.data_mut();
 
         let mut lead: usize = 0;
 
@@ -284,7 +354,7 @@ impl<N> Matrix<N> {
 
             let mut i: usize = row;
 
-            while data[index(i, lead)] == N::zero() {
+            while data[index(i, lead)] == T::Elem::ZERO {
                 i += 1;
 
                 if i == dims.rows.get() {
@@ -312,8 +382,8 @@ impl<N> Matrix<N> {
             {
                 let mut index_row = index(row, lead);
                 let lead_value = data[index_row];
-                if lead_value != N::one() {
-                    data[index_row] = N::one();
+                if lead_value != T::Elem::ONE {
+                    data[index_row] = T::Elem::ONE;
                     index_row += dims.rows.get();
 
                     for _ in (lead + 1)..dims.cols.get() {
@@ -332,11 +402,11 @@ impl<N> Matrix<N> {
                 let mut index_j = index(j, lead);
 
                 let lead_multiplicator = data[index_j];
-                if lead_multiplicator == N::zero() {
+                if lead_multiplicator == T::Elem::ZERO {
                     continue;
                 }
 
-                data[index_j] = N::zero();
+                data[index_j] = T::Elem::ZERO;
                 index_j += dims.rows.get();
                 let mut index_row = index(row, lead + 1);
 
@@ -363,8 +433,9 @@ impl<N> Matrix<N> {
     #[inline]
     pub fn lu_decomposition<E>(&mut self, eps: E) -> Option<Box<[usize]>>
     where
-        N: NumberFloat,
-        E: TryInto<Epsilon<N>>,
+        T: RawDataMut,
+        T::Elem: NumberFloat,
+        E: TryInto<Epsilon<T::Elem>>,
     {
         // Non-square
         if !self.dims().is_square() {
@@ -377,7 +448,7 @@ impl<N> Matrix<N> {
         for row in 0..nrows {
             // Find pivot_row, the row with the highest value in the row-column
             let mut pivot_row = row;
-            let mut max_val = N::ZERO;
+            let mut max_val = T::Elem::ZERO;
             for row_b in row..nrows {
                 let val = Float::abs(self[(row_b, row)]);
                 if !Float::is_finite(val) {
@@ -402,7 +473,7 @@ impl<N> Matrix<N> {
                     // guaranteed: row < pivot_row
                     let index_r = MatrixCoord::new(row, col).to_linear_unchecked(self.dims());
                     let index_p = index_r + (pivot_row - row);
-                    self.data.data.swap(index_r, index_p);
+                    self.data.data_mut().swap(index_r, index_p);
                 }
             }
 
@@ -423,125 +494,63 @@ impl<N> Matrix<N> {
 
         Some(p)
     }
-    /// Calculates the inverse of `self` using LU decomposition.
-    ///
-    /// Returns `None` if `self` isn't square, or if `self` is not invertible (as defined by `eps`).
-    #[expect(clippy::many_single_char_names, reason = "only within small scope")]
-    #[must_use]
-    #[inline]
-    pub fn inverse<E>(&self, eps: E) -> Option<Self>
-    where
-        N: NumberFloat,
-        E: TryInto<Epsilon<N>>,
-    {
-        // Non-square
-        if !self.dims().is_square() {
-            return None;
-        }
-        let eps = eps.try_into().ok()?;
-        let nrow = self.nrow().get();
-
-        if nrow == 2 {
-            const NZ2: NonZeroUsize = NonZeroUsize::new(2).expect("2 > 0");
-            // ab cd => 02 13
-            #[expect(clippy::unreachable, reason = "panic implies bug")]
-            let &[a, c, b, d] = self.internal_data() else {
-                unreachable!("2x2 = 4")
-            };
-            // ad-bc
-            let det = a * d - b * c;
-            if eps.is_zero(det) {
-                return None;
-            };
-            // d -c -b a
-            let inv = vec![d / det, -c / det, -b / det, a / det];
-            return Self::new(inv, NZ2);
-        } else if nrow == 3 {
-            const NZ3: NonZeroUsize = NonZeroUsize::new(3).expect("3 > 0");
-            // abc def ghi => 036 147 258
-            #[expect(clippy::unreachable, reason = "panic implies bug")]
-            let &[a, d, g, b, e, h, c, f, i] = self.internal_data() else {
-                unreachable!("3x3=9")
-            };
-            let mut inv = vec![
-                e * i - f * h,
-                -(d * i - f * g),
-                d * h - e * g, // ABC
-                -(b * i - c * h),
-                a * i - c * g,
-                -(a * h - b * g), // DEF
-                b * f - c * e,
-                -(a * f - c * d),
-                a * e - b * d, // GHI
-            ];
-            let det = a * inv[0] + b * inv[1] + c * inv[2]; // aA + bB +cC
-            if eps.is_zero(det) {
-                return None;
-            };
-            for v in &mut inv {
-                *v /= det;
-            }
-            return Self::new(inv, NZ3);
-        }
-
-        let (lu, p) = {
-            let mut lu = self.clone();
-            let p = lu.lu_decomposition(eps)?;
-            (lu, p)
-        };
-
-        let mut inv = Self::from_value(N::ZERO, self.dims());
-
-        // Solve for each column of the identity mat
-        for col in 0..nrow {
-            // Solve LY = P
-            for row in 0..nrow {
-                let mut sum = if p[row] == col { N::ONE } else { N::ZERO };
-                for k in 0..row {
-                    sum -= lu[(row, k)] * inv[(k, col)];
-                }
-                inv[(row, col)] = sum;
-            }
-
-            // Solve UX =  Y for X
-            for row in (0..nrow).rev() {
-                let mut sum = inv[(row, col)];
-                for k in (row + 1)..nrow {
-                    sum -= lu[(row, k)] * inv[(k, col)];
-                }
-                inv[(row, col)] = sum / lu[(row, row)];
-            }
-        }
-
-        Some(inv)
-    }
 }
 
-impl<'bdata, N> MatrixRef<'bdata, N> {
+impl<N> Matrix<N> {
+    /// Constructs a new owned matrix representation filled with some value `data`.
     #[inline]
-    pub fn new<NZ>(data: &'bdata [N], rows: NZ) -> Option<Self>
+    pub fn from_value<D>(data: N, dims: D) -> Self
     where
+        N: Copy,
+        D: Into<MatrixDims>,
+    {
+        let dims: MatrixDims = dims.into();
+        Self {
+            data: vec![data; dims.len().get()],
+            dims,
+        }
+    }
+    /// Constructs a new identity matrix
+    #[inline]
+    pub fn new_identity<NZ>(rows: NZ) -> Option<Self>
+    where
+        N: Number,
         NZ: TryInto<NonZeroUsize>,
     {
         let rows = rows.try_into().ok()?;
-        let dims = MatrixDims::from_row_count(data.len(), rows)?;
-        let data = BorrowedMatrixData::new(data);
-        Some(Self { data, dims })
+        let dims = MatrixDims::new(rows, rows);
+        let mut m = Self::from_value(N::ZERO, dims);
+        for r in 0..rows.get() {
+            m[(r, r)] = N::ONE;
+        }
+        Some(m)
+    }
+    /// Resizes the matrix.
+    /// Does not respect data on expansion.
+    #[inline]
+    pub fn resize<D>(&mut self, dims: D)
+    where
+        N: Copy + num_traits::ConstZero,
+        D: Into<MatrixDims>,
+    {
+        let dims: MatrixDims = dims.into();
+        if dims == self.dims() {
+            return;
+        }
+        self.data.resize(dims.len().get(), N::ZERO);
+        self.dims = dims;
     }
 }
 
-impl<T, N> Dimensions for MatrixBase<T, N>
-where
-    T: RawData<Elem = N>,
-{
+impl<T> Dimensions for MatrixBase<T> {
     /// Returns the matrix dimension.
     #[inline]
     fn dims(&self) -> MatrixDims { self.dims }
 }
 
-impl<T, N, I> Index<I> for MatrixBase<T, N>
+impl<T, I> Index<I> for MatrixBase<T>
 where
-    T: RawData<Elem = N>,
+    T: RawData,
     I: Into<MatrixCoord>,
 {
     type Output = T::Elem;
@@ -551,42 +560,43 @@ where
     #[inline]
     fn index(&self, index: I) -> &Self::Output {
         let index = index.into().to_linear_unchecked(self.dims);
-        &self.internal_data()[index]
+        &self.data.data()[index]
     }
 }
-impl<N, I> IndexMut<I> for Matrix<N>
+impl<T, I> IndexMut<I> for MatrixBase<T>
 where
+    T: RawDataMut,
     I: Into<MatrixCoord>,
 {
     #[inline]
     fn index_mut(&mut self, index: I) -> &mut Self::Output {
         let index = index.into().to_linear_unchecked(self.dims());
-        &mut self.data.data[index]
+        &mut self.data.data_mut()[index]
     }
 }
 
-impl<T, N> From<&MatrixBase<T, N>> for Matrix<N>
+impl<T> From<&MatrixBase<T>> for Matrix<T::Elem>
 where
-    T: RawData<Elem = N>,
-    N: Copy,
+    T: RawData,
+    T::Elem: Copy,
 {
     #[inline]
-    fn from(matrix: &MatrixBase<T, N>) -> Self { matrix.to_matrix() }
+    fn from(matrix: &MatrixBase<T>) -> Self { matrix.to_matrix() }
 }
-impl<'bdata, T, N> From<&'bdata MatrixBase<T, N>> for MatrixRef<'bdata, N>
+impl<'bdata, T> From<&'bdata MatrixBase<T>> for MatrixRef<'bdata, T::Elem>
 where
-    T: RawData<Elem = N>,
+    T: RawData,
 {
     #[inline]
-    fn from(matrix: &'bdata MatrixBase<T, N>) -> Self { matrix.to_matrixref() }
+    fn from(matrix: &'bdata MatrixBase<T>) -> Self { matrix.to_matrixref() }
 }
 
-impl<T, N> PointSet for MatrixBase<T, N>
+impl<T> PointSet for MatrixBase<T>
 where
-    T: RawData<Elem = N>,
-    N: Number,
+    T: RawData,
+    T::Elem: Number,
 {
-    type Value = N;
+    type Value = T::Elem;
     type Id = usize;
     /// Returns the number of rows in the matrix
     #[inline]
@@ -605,34 +615,36 @@ where
     /// Panics on oob.
     #[expect(clippy::renamed_function_params, reason = "a matrix has rows, not ids")]
     #[inline]
-    fn coord(&self, row: usize, col: usize) -> N {
+    fn coord(&self, row: usize, col: usize) -> Self::Value {
         let idx = row + col * self.dims.rows.get();
-        self.internal_data()[idx]
+        self.data.data()[idx]
     }
     /// Returns the element at coordinates `(row, col)`.
     /// Returns `None` if the coordinates are oob.
     #[expect(clippy::renamed_function_params, reason = "a matrix has rows, not ids")]
     #[inline]
-    fn get_coord(&self, row: usize, col: usize) -> Option<N> { self.get((row, col)).copied() }
+    fn get_coord(&self, row: usize, col: usize) -> Option<Self::Value> {
+        self.get((row, col)).copied()
+    }
     /// Returns an iterator over the coords of `row`, or `None` if `row` does not exist.
     #[expect(clippy::renamed_function_params, reason = "a matrix has rows, not ids")]
     #[must_use]
     #[inline]
-    fn get_coords(&self, row: usize) -> Option<impl ExactSizeIterator<Item = &N>> {
+    fn get_coords(&self, row: usize) -> Option<impl ExactSizeIterator<Item = &Self::Value>> {
         self.row_iter(row)
     }
     /// Returns the squared euclidean distance between rows `id_a` and `id_b`.
     /// Panics on oob.
     #[inline]
-    fn sq_distance_between(&self, id_a: usize, id_b: usize) -> N {
+    fn sq_distance_between(&self, id_a: usize, id_b: usize) -> Self::Value {
         if id_a == id_b {
-            return N::zero();
+            return <Self::Value as ConstZero>::ZERO;
         }
         let mut idx = id_a.min(id_b);
         let idx_diff = id_a.abs_diff(id_b);
-        let mut sum = N::zero();
+        let mut sum = <Self::Value as ConstZero>::ZERO;
         for _ in 0..self.ncol().get() {
-            let diff = self.internal_data()[idx] - self.internal_data()[idx + idx_diff];
+            let diff = self.data.data()[idx] - self.data.data()[idx + idx_diff];
             sum += diff * diff;
             idx += self.nrow().get();
         }
@@ -641,7 +653,7 @@ where
     /// Returns the squared euclidean distance between rows `id_a` and `id_b`.
     /// Returns `None` if any row is oob.
     #[inline]
-    fn get_sq_distance_between(&self, id_a: usize, id_b: usize) -> Option<N> {
+    fn get_sq_distance_between(&self, id_a: usize, id_b: usize) -> Option<Self::Value> {
         (self.contains(id_a) && self.contains(id_b)).then(|| self.sq_distance_between(id_a, id_b))
     }
 }

--- a/envisim_utils/src/matrix/mod.rs
+++ b/envisim_utils/src/matrix/mod.rs
@@ -74,6 +74,40 @@ impl<T> MatrixBase<T> {
         let dims = MatrixDims::from_row_count(data.data().len(), rows)?;
         Some(Self { data, dims })
     }
+    /// Constructs a new owned matrix representation filled with some value `data`.
+    #[inline]
+    pub fn from_value<D>(value: T::Elem, dims: D) -> Self
+    where
+        T: RawData + From<Vec<T::Elem>>,
+        T::Elem: Copy,
+        D: Into<MatrixDims>,
+    {
+        let dims: MatrixDims = dims.into();
+        let data = vec![value; dims.len().get()];
+        Self {
+            data: data.into(),
+            dims,
+        }
+    }
+    /// Constructs a new identity matrix
+    #[inline]
+    pub fn new_identity<NZ>(rows: NZ) -> Option<Self>
+    where
+        T: RawData + From<Vec<T::Elem>>,
+        T::Elem: ConstZero + ConstOne + Copy,
+        NZ: TryInto<NonZeroUsize>,
+    {
+        let rows = rows.try_into().ok()?;
+        let dims = MatrixDims::new(rows, rows);
+        let mut data = vec![T::Elem::ZERO; dims.len().get()];
+        for e in data.iter_mut().step_by(rows.get() + 1) {
+            *e = T::Elem::ONE;
+        }
+        Some(Self {
+            data: data.into(),
+            dims,
+        })
+    }
     /// Constructs a borrowed matrix representation from a matrix.
     #[inline]
     pub fn to_matrixref(&self) -> MatrixRef<'_, T::Elem>
@@ -497,34 +531,6 @@ impl<T> MatrixBase<T> {
 }
 
 impl<N> Matrix<N> {
-    /// Constructs a new owned matrix representation filled with some value `data`.
-    #[inline]
-    pub fn from_value<D>(data: N, dims: D) -> Self
-    where
-        N: Copy,
-        D: Into<MatrixDims>,
-    {
-        let dims: MatrixDims = dims.into();
-        Self {
-            data: vec![data; dims.len().get()],
-            dims,
-        }
-    }
-    /// Constructs a new identity matrix
-    #[inline]
-    pub fn new_identity<NZ>(rows: NZ) -> Option<Self>
-    where
-        N: Number,
-        NZ: TryInto<NonZeroUsize>,
-    {
-        let rows = rows.try_into().ok()?;
-        let dims = MatrixDims::new(rows, rows);
-        let mut m = Self::from_value(N::ZERO, dims);
-        for r in 0..rows.get() {
-            m[(r, r)] = N::ONE;
-        }
-        Some(m)
-    }
     /// Resizes the matrix.
     /// Does not respect data on expansion.
     #[inline]

--- a/envisim_utils/src/matrix/mod.rs
+++ b/envisim_utils/src/matrix/mod.rs
@@ -159,11 +159,25 @@ impl<T> MatrixBase<T> {
         let coord = coord.into();
         self.dims.contains(coord).then(|| &mut self[coord])
     }
+    /// Swaps the element at `coord_a` with the element at `coord_b`.
+    #[inline]
+    pub fn swap<CA, CB>(&mut self, coord_a: CA, coord_b: CB) -> Option<()>
+    where
+        T: RawDataMut,
+        T::Elem: Copy,
+        CA: Into<MatrixCoord>,
+        CB: Into<MatrixCoord>,
+    {
+        let idx_a = coord_a.into().to_linear(self.dims)?;
+        let idx_b = coord_b.into().to_linear(self.dims)?;
+        self.data.data_mut().swap(idx_a, idx_b);
+        Some(())
+    }
     /// Returns an iterator of the elements in a row.
     /// Returns `None` if the row is invalid.
     #[must_use]
     #[inline]
-    pub fn row_iter(&self, row: usize) -> Option<impl ExactSizeIterator<Item = &T::Elem>>
+    pub fn row_iter(&self, row: usize) -> Option<impl ExactSizeIterator<Item = &T::Elem> + Clone>
     where
         T: RawData,
     {
@@ -192,7 +206,7 @@ impl<T> MatrixBase<T> {
     /// Returns `None` if the column is invalid.
     #[must_use]
     #[inline]
-    pub fn col_iter(&self, col: usize) -> Option<impl ExactSizeIterator<Item = &T::Elem>>
+    pub fn col_iter(&self, col: usize) -> Option<impl ExactSizeIterator<Item = &T::Elem> + Clone>
     where
         T: RawData,
     {

--- a/envisim_utils/src/matrix/raw_data.rs
+++ b/envisim_utils/src/matrix/raw_data.rs
@@ -10,31 +10,92 @@
 // You should have received a copy of the GNU Affero General Public License along with this
 // program. If not, see <https://www.gnu.org/licenses/>.
 
-//! Raw data -- internal data structure
+//! Internal data structure traits
+
+use std::borrow::Cow;
+use std::rc::Rc;
+use std::sync::Arc;
 
 /// Data container trait
 pub trait RawData: Sized {
     type Elem;
+    /// Returns a reference (view) to the internal data, expected to be in column major order.
     #[must_use]
     fn data(&self) -> &[Self::Elem];
 }
 /// Mutable data container trait
 pub trait RawDataMut: RawData {
+    /// Returns a mutable reference to the internal data, expected to be in column major order.
     #[must_use]
     fn data_mut(&mut self) -> &mut [Self::Elem];
 }
 
-impl<N> RawData for Vec<N> {
+// View containers
+impl<N, const L: usize> RawData for [N; L] {
     type Elem = N;
     #[inline]
-    fn data(&self) -> &[Self::Elem] { self.as_slice() }
-}
-impl<N> RawDataMut for Vec<N> {
-    #[inline]
-    fn data_mut(&mut self) -> &mut [Self::Elem] { self.as_mut_slice() }
+    fn data(&self) -> &[Self::Elem] { self }
 }
 impl<N> RawData for &[N] {
     type Elem = N;
     #[inline]
     fn data(&self) -> &[Self::Elem] { self }
+}
+impl<N> RawData for &mut [N] {
+    type Elem = N;
+    #[inline]
+    fn data(&self) -> &[Self::Elem] { self }
+}
+impl<N> RawData for Vec<N> {
+    type Elem = N;
+    #[inline]
+    fn data(&self) -> &[Self::Elem] { self }
+}
+impl<N> RawData for Box<[N]> {
+    type Elem = N;
+    #[inline]
+    fn data(&self) -> &[Self::Elem] { self }
+}
+impl<N> RawData for Cow<'_, [N]>
+where
+    N: Clone,
+{
+    type Elem = N;
+    #[inline]
+    fn data(&self) -> &[Self::Elem] { self }
+}
+impl<N> RawData for Rc<[N]> {
+    type Elem = N;
+    #[inline]
+    fn data(&self) -> &[Self::Elem] { self }
+}
+impl<N> RawData for Arc<[N]> {
+    type Elem = N;
+    #[inline]
+    fn data(&self) -> &[Self::Elem] { self }
+}
+
+// Mutable containers
+impl<N, const L: usize> RawDataMut for [N; L] {
+    #[inline]
+    fn data_mut(&mut self) -> &mut [Self::Elem] { self }
+}
+impl<N> RawDataMut for &mut [N] {
+    #[inline]
+    fn data_mut(&mut self) -> &mut [Self::Elem] { self }
+}
+impl<N> RawDataMut for Vec<N> {
+    #[inline]
+    fn data_mut(&mut self) -> &mut [Self::Elem] { self }
+}
+impl<N> RawDataMut for Box<[N]> {
+    #[inline]
+    fn data_mut(&mut self) -> &mut [Self::Elem] { self }
+}
+impl<N> RawDataMut for Cow<'_, [N]>
+where
+    N: Clone,
+{
+    #[inline]
+    fn data_mut(&mut self) -> &mut [Self::Elem] { self.to_mut() }
 }

--- a/envisim_utils/src/matrix/raw_data.rs
+++ b/envisim_utils/src/matrix/raw_data.rs
@@ -18,69 +18,23 @@ pub trait RawData: Sized {
     #[must_use]
     fn data(&self) -> &[Self::Elem];
 }
-
-#[expect(
-    clippy::field_scoped_visibility_modifiers,
-    reason = "ok within matrix module"
-)]
-#[must_use]
-#[derive(Debug, Clone)]
-pub struct OwnedMatrixData<N> {
-    /// Internal data vector
-    pub(super) data: Vec<N>,
-}
-impl<N> OwnedMatrixData<N> {
-    /// Constructs a new owned matrix data
-    #[inline]
-    pub fn new(data: Vec<N>) -> Self { Self { data } }
+/// Mutable data container trait
+pub trait RawDataMut: RawData {
+    #[must_use]
+    fn data_mut(&mut self) -> &mut [Self::Elem];
 }
 
-impl<N> RawData for OwnedMatrixData<N> {
+impl<N> RawData for Vec<N> {
     type Elem = N;
     #[inline]
-    fn data(&self) -> &[Self::Elem] { &self.data }
+    fn data(&self) -> &[Self::Elem] { self.as_slice() }
 }
-impl<N> From<&BorrowedMatrixData<'_, N>> for OwnedMatrixData<N>
-where
-    N: Copy,
-{
+impl<N> RawDataMut for Vec<N> {
     #[inline]
-    fn from(data: &BorrowedMatrixData<N>) -> Self { Self::new(data.data().to_vec()) }
+    fn data_mut(&mut self) -> &mut [Self::Elem] { self.as_mut_slice() }
 }
-impl<N> From<&[N]> for OwnedMatrixData<N>
-where
-    N: Copy,
-{
-    #[inline]
-    fn from(data: &[N]) -> Self { Self::new(data.to_vec()) }
-}
-impl<N> From<Vec<N>> for OwnedMatrixData<N> {
-    #[inline]
-    fn from(data: Vec<N>) -> Self { Self::new(data) }
-}
-
-#[must_use]
-#[derive(Debug, Clone, Copy)]
-pub struct BorrowedMatrixData<'bdata, N> {
-    /// Internal data reference
-    data: &'bdata [N],
-}
-impl<'bdata, N> BorrowedMatrixData<'bdata, N> {
-    /// Constructs a new borrowed matrix data
-    #[inline]
-    pub fn new(data: &'bdata [N]) -> Self { Self { data } }
-}
-
-impl<N> RawData for BorrowedMatrixData<'_, N> {
+impl<N> RawData for &[N] {
     type Elem = N;
     #[inline]
-    fn data(&self) -> &[Self::Elem] { self.data }
-}
-impl<'borrow, N> From<&'borrow OwnedMatrixData<N>> for BorrowedMatrixData<'borrow, N> {
-    #[inline]
-    fn from(data: &'borrow OwnedMatrixData<N>) -> Self { Self::new(data.data()) }
-}
-impl<'bdata, N> From<&'bdata [N]> for BorrowedMatrixData<'bdata, N> {
-    #[inline]
-    fn from(data: &'bdata [N]) -> Self { Self::new(data) }
+    fn data(&self) -> &[Self::Elem] { self }
 }

--- a/rsamplr_pkg/src/rust/src/lib.rs
+++ b/rsamplr_pkg/src/rust/src/lib.rs
@@ -133,12 +133,15 @@ fn rust_distributionally_balanced_design(
         .set_spreading(aux)?
         .set_max_iterations(iter)?;
 
-    let s = match r_method {
-        "dbd_tc" => options.dbd_tc(&mut rng, dbs_options)?.into_buckets(),
-        "dbd_circular" | &_ => options.dbd_circular(&mut rng, dbs_options)?.into_sequence(),
-    };
-
-    return_sample(s)
+    match r_method {
+        "dbd_tc" => return_sample(options.dbd_tc(&mut rng, dbs_options)?.into_buckets().data()),
+        "dbd_circular" | &_ => return_sample(
+            options
+                .dbd_circular(&mut rng, dbs_options)?
+                .into_sequence()
+                .as_ref(),
+        ),
+    }
 }
 
 #[savvy]

--- a/rsamplr_pkg/src/rust/src/utils.rs
+++ b/rsamplr_pkg/src/rust/src/utils.rs
@@ -64,14 +64,15 @@ where
 /// Converts sample to [`Sexp`]
 /// # Errors
 /// If not possible to convert a sample index to i32
-#[expect(clippy::needless_pass_by_value, reason = "no use for sample after")]
 #[inline]
-pub fn return_sample(sample: Vec<usize>) -> savvy::Result<Sexp> {
-    let mut out = OwnedIntegerSexp::new(sample.len())?;
-
-    for (i, &v) in sample.iter().enumerate() {
-        out[i] = to_i32(v)? + 1;
+pub fn return_sample<T>(sample: T) -> savvy::Result<Sexp>
+where
+    T: AsRef<[usize]>,
+{
+    let slice = sample.as_ref();
+    let mut out = OwnedIntegerSexp::new(slice.len())?;
+    for (o, s) in out.iter_mut().zip(slice.iter()) {
+        *o = to_i32(*s)? + 1;
     }
-
     Ok(Sexp::from(out))
 }


### PR DESCRIPTION
`dbd_tc` could use a `Matrix` instead of reinventing it all.

## envisim_utils
- Added `Matrix::swap`, for swapping two elements in a `Matrix`.